### PR TITLE
Adjust IDENTIFY_OUTPUT_RE for graphicsmagick

### DIFF
--- a/graphics/text/textgen
+++ b/graphics/text/textgen
@@ -61,7 +61,7 @@ SPACE_WIDTH = 10
 
 # Output from 'identify' looks like this:
 #  fontchars/font033.gif GIF 9x16 9x16+0+0 8-bit sRGB 32c 194B 0.000u 0:00.000
-IDENTIFY_OUTPUT_RE = re.compile(r'(\S+)\s(\S+)\s(\d+)x(\d+)\s')
+IDENTIFY_OUTPUT_RE = re.compile(r'(\S+)\s(\S+)\s(\d+)x(\d+)(\+\d+\+\d+)?\s')
 
 def get_image_dimensions(filename):
 	proc = subprocess.Popen([IDENTIFY_COMMAND, filename],


### PR DESCRIPTION
The 'identify' binary supplied in graphicsmagick-imagemagick-compat outputs
lines of the form

```
 fontchars/font033.gif GIF 9x16+0+0 PseudoClass 32c 8-bit 194 0.000u 0:01
```

However the IDENTIFY_OUTPUT_RE regex was written against an output which lacked
the +0+0 suffix to the dimensions. This patch adjusts accordingly.
