### PR TITLE
Adjust IDENTIFY_OUTPUT_RE for graphicsmagick

### DIFF
--- a/graphics/text/common.py
+++ b/graphics/text/common.py
@@ -9,7 +9,7 @@ IDENTIFY_COMMAND = 'identify'
 
 # Output from 'identify' looks like this:
 #  fontchars/font033.gif GIF 9x16 9x16+0+0 8-bit sRGB 32c 194B 0.000u 0:00.000
-IDENTIFY_OUTPUT_RE = re.compile(r'(\S+)\s(\S+)\s(\d+)x(\d+)\s')
+IDENTIFY_OUTPUT_RE = re.compile(r'(\S+)\s(\S+)\s(\d+)x(\d+)(\+\d+\+\d+)?\s')
 
 # Regexp to identify strings that are all lowercase (can use shorter height)
 LOWERCASE_RE = re.compile(r'^[a-z\!\. ]*$')


### PR DESCRIPTION
The 'identify' binary supplied in graphicsmagick-imagemagick-compat outputs
lines of the form

```
 fontchars/font033.gif GIF 9x16+0+0 PseudoClass 32c 8-bit 194 0.000u 0:01
```

However the IDENTIFY_OUTPUT_RE regex was written against an output which lacked
the +0+0 suffix to the dimensions. This patch adjusts accordingly.
