### PR TITLE
titlepic/create_caption: try alternative fonts

### DIFF
--- a/graphics/titlepic/create_caption
+++ b/graphics/titlepic/create_caption
@@ -1,11 +1,25 @@
 #!/bin/sh
 
+find_font() {
+	local font fontlist
+	fontlist=$(convert -list font | awk '$1=="Font:" { print $2 }')
+	for font in "$@" ; do
+		if echo $fontlist | grep -q $font ; then
+			echo $font
+			return
+		fi
+	done
+}
+
+font=$(find_font Helvetica-Bold Liberation-Sans-Bold DejaVu-Sans-Condensed-Bold)
+if [ -z "$font" ] ; then echo "Cannot find any fonts" ; exit 1 ; fi
+
 draw_with_footer() {
 	input_file=$1;
 	output_file=$2;
 	shift; shift
 
-	convert $input_file -fill white -font Helvetica-Bold      \
+	convert $input_file -fill white -font "$font"             \
 	  -pointsize 11                                           \
 	    -gravity southwest                                    \
 	      -draw "text 5,5 'https://freedoom.github.io/'"      \


### PR DESCRIPTION
Do not FTBFS if the user does not have ghostscript / gsfonts installed.
Instead try some other fonts commonly installed by Linux distributions.

The patch is written to be easily extendable with extra font names, but
to be independent of the order of "convert -list font" output. Each
listed font is searched for in turn, and the first one found is used.