### PR TITLE
make the build reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ $(FREEDOOM2): wadinfo_phase2.txt subdirs
 	$(DEUTEX) $(DEUTEX_ARGS) -iwad -lumps -patch -flats -sounds -musics -graphics -sprites -levels -build wadinfo_phase2.txt $@
 
 %.html: %.adoc
-	asciidoc $<
+	TZ=UTC asciidoc $<
 
 doc: $(patsubst %.adoc,%.html,$(wildcard *.adoc))
 


### PR DESCRIPTION
Hi,

This tiny tweak is needed to make the build reproducible.

Appart from having high packaging standards; having reproducible
build also sometimes help to identify some weird/old bugs;
and here that doesn't hurt either in anyway.

https://wiki.debian.org/ReproducibleBuilds/TimestampsInDocumentationGeneratedByAsciidoc