### PR TITLE
titlepic: use image instead of text, change footer

### DIFF
--- a/graphics/text/Makefile
+++ b/graphics/text/Makefile
@@ -15,7 +15,7 @@ TEXTGEN_GRAPHIC_LUMPS = \
   m_mess.gif   m_mouse.gif  m_multi.gif  m_player.gif m_serial.gif \
   m_setup.gif  m_sound.gif  m_stat.gif   m_status.gif m_tcpip.gif  \
   m_versen.gif m_video.gif  m_wad.gif    m_wadopt.gif m_weap.gif   \
-  prboom.gif                                                       \
+  prboom.gif   t_phase1.gif t_phase2.gif                           \
   m_ultra.gif  wibp1.gif    wibp2.gif    wibp3.gif    wibp4.gif    \
   wicolon.gif  wienter.gif  wif.gif      wifrgs.gif   wipcnt.gif   \
   wiminus.gif  wimstar.gif  wimstt.gif   wiostf.gif   wiosti.gif   \

--- a/graphics/text/config.py
+++ b/graphics/text/config.py
@@ -64,6 +64,10 @@ white_graphics = {
 	'wibp3': 'P3',
 	'wibp4': 'P4',
 	'wicolon': ':',
+	
+	# These files are for the title screens of Phase 1 and Phase 2
+	't_phase1': 'PHASE 1',
+	't_phase2': 'PHASE 2',
 
 	# Note: level names are also included in this dictionary, with
 	# the data added programatically from the DEHACKED lump, see
@@ -75,10 +79,6 @@ blue_graphics = {
 	'm_episod': 'Choose Chapter:',
 	'm_optttl': 'OPTIONS',
 	'm_skill': 'Choose Skill Level:',
-	
-	# These files are for the title screens of Phase 1 and Phase 2
-	't_phase1': 'PHASE 1',
-	't_phase2': 'PHASE 2',
 }
 
 red_graphics = {

--- a/graphics/text/config.py
+++ b/graphics/text/config.py
@@ -75,6 +75,10 @@ blue_graphics = {
 	'm_episod': 'Choose Chapter:',
 	'm_optttl': 'OPTIONS',
 	'm_skill': 'Choose Skill Level:',
+	
+	# These files are for the title screens of Phase 1 and Phase 2
+	't_phase1': 'PHASE 1',
+	't_phase2': 'PHASE 2',
 }
 
 red_graphics = {

--- a/graphics/titlepic/Makefile
+++ b/graphics/titlepic/Makefile
@@ -6,12 +6,18 @@ m_doom.gif: ../m_doom.gif
 m_dm.gif: ../m_dm.gif
 	convert -transparent '#00ffff' ../m_dm.gif m_dm.gif
 
-fd1title.gif: titlepic.gif m_doom.gif
-	./create_caption titlepic.gif m_doom.gif "Phase 1" $@
+t_phase1.gif: ../t_phase1.gif
+	convert -transparent '#00ffff' ../t_phase1.gif t_phase1.gif
+	
+t_phase2.gif: ../t_phase2.gif
+	convert -transparent '#00ffff' ../t_phase2.gif t_phase2.gif
+
+fd1title.gif: titlepic.gif m_doom.gif t_phase1.gif
+	./create_caption titlepic.gif m_doom.gif t_phase1.gif $@
 	cp $@ ../
 
-fd2title.gif: titlepic.gif m_doom.gif
-	./create_caption titlepic.gif m_doom.gif "Phase 2" $@
+fd2title.gif: titlepic.gif m_doom.gif t_phase2.gif
+	./create_caption titlepic.gif m_doom.gif t_phase2.gif $@
 	cp $@ ../
 
 fdmtitle.gif: ../captainw/fdmtitle.gif
@@ -19,7 +25,8 @@ fdmtitle.gif: ../captainw/fdmtitle.gif
 	cp $@ ../
 
 clean:
-	rm -f m_dm.gif m_doom.gif fd1title.gif fd2title.gif fdmtitle.gif \
-	      ../fd1title.gif ../fd2title.gif ../fdmtitle.gif
+	rm -f m_dm.gif m_doom.gif fd1title.gif fd2title.gif fdmtitle.gif      \
+	      ../fd1title.gif ../fd2title.gif ../fdmtitle.gif ../t_phase1.gif \
+	      t_phase1.gif ../t-phase2.gif t_phase2.gif	      
 
 .PHONY: clean

--- a/graphics/titlepic/Makefile
+++ b/graphics/titlepic/Makefile
@@ -25,8 +25,8 @@ fdmtitle.gif: ../captainw/fdmtitle.gif
 	cp $@ ../
 
 clean:
-	rm -f m_dm.gif m_doom.gif fd1title.gif fd2title.gif fdmtitle.gif      \
-	      ../fd1title.gif ../fd2title.gif ../fdmtitle.gif ../t_phase1.gif \
-	      t_phase1.gif ../t_phase2.gif t_phase2.gif	      
+	rm -f m_dm.gif m_doom.gif fd1title.gif fd2title.gif fdmtitle.gif   \
+	      ../fd1title.gif ../fd2title.gif ../fdmtitle.gif t_phase1.gif \
+	      t_phase2.gif	      
 
 .PHONY: clean

--- a/graphics/titlepic/Makefile
+++ b/graphics/titlepic/Makefile
@@ -27,6 +27,6 @@ fdmtitle.gif: ../captainw/fdmtitle.gif
 clean:
 	rm -f m_dm.gif m_doom.gif fd1title.gif fd2title.gif fdmtitle.gif      \
 	      ../fd1title.gif ../fd2title.gif ../fdmtitle.gif ../t_phase1.gif \
-	      t_phase1.gif ../t-phase2.gif t_phase2.gif	      
+	      t_phase1.gif ../t_phase2.gif t_phase2.gif	      
 
 .PHONY: clean

--- a/graphics/titlepic/create_caption
+++ b/graphics/titlepic/create_caption
@@ -34,7 +34,7 @@ if [ $# = 4 ]; then
 	  -gravity north                                                    \
 	  -draw "image over 0,18 0,0 '$2'"                                  \
 	  -gravity south                                                    \
-	    -draw "image over 0,-25 0,0 '$3'"
+	  -draw "image over 0,-25 0,0 '$3'"
 else
 	draw_with_footer "$1" "$2"
 fi

--- a/graphics/titlepic/create_caption
+++ b/graphics/titlepic/create_caption
@@ -19,7 +19,7 @@ draw_with_footer() {
 	output_file=$2;
 	shift; shift
 
-	convert $input_file -fill orange -font "$font" +dither -style oblique  \
+	convert $input_file -fill orange -font "$font" +dither                 \
 	  -pointsize 11                                                        \
 	    -gravity southwest                                                 \
 	      -draw "text 5,5 'Freedoom, © 2001-2017'"                         \
@@ -34,7 +34,7 @@ if [ $# = 4 ]; then
 	  -gravity north                                                    \
 	  -draw "image over 0,18 0,0 '$2'"                                  \
 	  -gravity south                                                    \
-	  -draw "image over 0,25 0,0 '$3'"
+	  -draw "image over 0,30 0,0 '$3'"
 else
 	draw_with_footer "$1" "$2"
 fi

--- a/graphics/titlepic/create_caption
+++ b/graphics/titlepic/create_caption
@@ -19,13 +19,13 @@ draw_with_footer() {
 	output_file=$2;
 	shift; shift
 
-	convert $input_file -fill white -font "$font" +dither     \
-	  -pointsize 11                                           \
-	    -gravity southwest                                    \
-	      -draw "text 5,5 'https://freedoom.github.io/'"      \
-	    -gravity southeast                                    \
-	      -draw "text 10,5 'Version: $VERSION'"               \
-	    "$@"                                                  \
+	convert $input_file -fill blue -font "$font" +dither -style oblique  \
+	  -pointsize 11                                                      \
+	    -gravity southwest                                               \
+	      -draw "text 5,5 'Freedoom, © 2001-2017'"                       \
+	    -gravity southeast                                               \
+	      -draw "text 10,5 '$VERSION'"                                   \
+	    "$@"                                                             \
 	    $output_file
 }
 
@@ -33,9 +33,8 @@ if [ $# = 4 ]; then
 	draw_with_footer "$1" "$4"                                          \
 	  -gravity north                                                    \
 	  -draw "image over 0,18 0,0 '$2'"                                  \
-	  -pointsize 20                                                     \
-	    -draw "fill black stroke-width 4 stroke black text -5,160 '$3'" \
-	    -draw "text -5,160 '$3'"
+	  -gravity south                                                    \
+	    -draw "image over 0,-25 0,0 '$3'"
 else
 	draw_with_footer "$1" "$2"
 fi

--- a/graphics/titlepic/create_caption
+++ b/graphics/titlepic/create_caption
@@ -19,13 +19,13 @@ draw_with_footer() {
 	output_file=$2;
 	shift; shift
 
-	convert $input_file -fill blue -font "$font" +dither -style oblique  \
-	  -pointsize 11                                                      \
-	    -gravity southwest                                               \
-	      -draw "text 5,5 'Freedoom, © 2001-2017'"                       \
-	    -gravity southeast                                               \
-	      -draw "text 10,5 '$VERSION'"                                   \
-	    "$@"                                                             \
+	convert $input_file -fill orange -font "$font" +dither -style oblique  \
+	  -pointsize 11                                                        \
+	    -gravity southwest                                                 \
+	      -draw "text 5,5 'Freedoom, © 2001-2017'"                         \
+	    -gravity southeast                                                 \
+	      -draw "text 10,5 '$VERSION'"                                     \
+	    "$@"                                                               \
 	    $output_file
 }
 

--- a/graphics/titlepic/create_caption
+++ b/graphics/titlepic/create_caption
@@ -34,7 +34,7 @@ if [ $# = 4 ]; then
 	  -gravity north                                                    \
 	  -draw "image over 0,18 0,0 '$2'"                                  \
 	  -gravity south                                                    \
-	  -draw "image over 0,-25 0,0 '$3'"
+	  -draw "image over 0,25 0,0 '$3'"
 else
 	draw_with_footer "$1" "$2"
 fi


### PR DESCRIPTION
Rather than using the bland fonts for the titlepic, instead generate 
images using Freedoom's font and textgen. These images get overlayed
where the "Phase 1" and "Phase 2" white-lettered words used to be.

Also, replace the website URL on the titlepic with a copyright notice,
as the website URL is already mentioned on the help screen (where
it should be). And removed the "Version: " part of the version footer
text because it's not necessary. Finally, make footer text orange 
because it stands out well in a nice way :)

Preview: http://imgur.com/a/9PtzQ