### PR TITLE
fdmmpinf: remove "exittext" property

### DIFF
--- a/lumps/fdmmpinf.lmp
+++ b/lumps/fdmmpinf.lmp
@@ -14,33 +14,14 @@ map MAP30 lookup "HUSTR_30"
 }
 
 // Show no intermissions text between levels.
-cluster 5
-{
-	exittext = ""
-}
+cluster 5 {}
 
-cluster 6
-{
-	exittext = ""
-}
+cluster 6 {}
 
-cluster 7
-{
-	exittext = ""
-}
+cluster 7 {}
 
-cluster 8
-{
-	exittext = ""
-}
+cluster 8 {}
 
-cluster 9
-{
-	exittext = ""
-}
+cluster 9 {}
 
-cluster 10
-{
-	exittext = ""
-}
-
+cluster 10 {}


### PR DESCRIPTION
Rather than showing an empty screen, don't
show anything at all. This will proceed onto
the next map without any fake intermission
screens being displayed. This is a much better
solution for removing the usage of intermission
screens for FreeDM, on ZDoom ports.