### PR TITLE
textures.cfg: fix DBRAIN animation.

### DIFF
--- a/lumps/textures/textures.cfg
+++ b/lumps/textures/textures.cfg
@@ -1200,28 +1200,8 @@ CRACKLE2        64      128
 *   RW44_2      0       0
 CRACKLE4        64      128
 *   RW44_4      0       0
-DBRAIN1         128     128
+DBRAIN1         64      32
 *   RWDM11A     0       0
-*   MC1         0       0
-*   MC2         0       0
-*   MC3         0       0
-*   MC4         0       0
-*   MC5         0       0
-*   MC6         0       0
-*   MC7         0       0
-*   MC8         0       0
-*   MC9         0       0
-*   MC10        0       0
-*   MC11        0       0
-*   MC12        0       0
-*   MC13        0       0
-*   MC14        0       0
-*   MC15        0       0
-*   MC16        0       0
-*   MC17        0       0
-*   MC18        0       0
-*   MC19        0       0
-*   MC20        0       0
 DBRAIN2         64      32
 *   RWDM11B     0       0
 DBRAIN3         64      32

--- a/lumps/textures/textures.cfg
+++ b/lumps/textures/textures.cfg
@@ -2747,6 +2747,8 @@ MIDBARS3        64      72
 *   RW45_1      0       0
 MARBFAC3        128     128
 *   MWALL5_1    0       0
+MC1             128     128
+*   MC1         0       0
 MC2             128     128
 *   MC2         0       0
 MC3             128     128
@@ -2781,6 +2783,8 @@ MC18            128     128
 *   MC18        0       0
 MC19            128     128
 *   MC19        0       0
+MC20             128     128
+*   MC20         0       0
 
 ; These are "new" textures that are really just here so that all patches
 ; needed for Plutonia compatibility are included. plutonia.wad has these


### PR DESCRIPTION
Set DBRAIN1's size to 64x32, and remove MC patches from it.

This should address the issues brought to attention in #406 and [this thread on Doomworld](https://www.doomworld.com/forum/topic/93689-the-lava-flow-texture-is-bugged/).

Plutonia compatibility can be achieved by creating a separate PWAD with Plutonia's texture definitions. This is why the MC and AROCK animations work when playing Freedoom with Plutonia 2 or PRCP. Plutonia 2 and PRCP both include the Plutonia texture definitions, in addition to a few new ones.