### PR TITLE
Added targets, variables and help for wad2image integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /CREDITS.txt
 lumps/freedoom.lmp
 lumps/freedm.lmp
+/scripts/wad2image
 /wads/
 wad*.txt
 *.bak

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 lumps/freedoom.lmp
 lumps/freedm.lmp
 /scripts/wad2image
+/wad-images/
 /wads/
 wad*.txt
 *.bak

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ else
 	JSON=$(JSON) VERSION=$(VERSION) scripts/makejson
 endif
 
-clean:
+clean: wad-image-clean
 	rm -f	*.html deutex.log $(OBJS) \
 		./COPYING.txt ./CREDITS.txt \
 		./wadinfo.txt ./wadinfo_phase1.txt \
@@ -122,6 +122,92 @@ bindir?=/bin
 mandir?=/share/man
 waddir?=/share/games/doom
 target=$(DESTDIR)$(prefix)
+
+# Set variables that are common to wad-image* targets.
+WI_LEVELS := levels
+WI_SCRIPTS := scripts
+WI_ALL_OPTIONS := $(WI_OPTIONS) $(if $(WI_BW), --colors-images bw,) \
+    $(if $(WI_CMD), --show-cmd $(WI_CMD),) $(if $(WI_GIF), -d gif,) \
+    $(if $(WI_NO_SHOW),, -s) $(if $(WI_VERBOSE), -v,)
+WI_IMAGES := $(WI_SCRIPTS)/wad2image/images
+wad-image-common:
+
+# Generating images for WADs in "levels" directory and show the result.
+WI_LATEST := $(shell ls -1t $(WI_LEVELS)/*.wad | head -n 1)
+WI_FILES := $(if $(WI_PATT), $(WI_LEVELS)/$(WI_PATT).wad, $(WI_LATEST))
+wad-image: wad-image-common
+	@echo "Generating images for WADs in \"$(WI_LEVELS)\"."
+	scripts/wad2image/bin/wad2image.py $(WI_ALL_OPTIONS) $(WI_FILES)
+
+wad-image-clean: wad-image-common
+	rm -rf $(WI_IMAGES)
+
+# Diffing WADs in "levels" using git and show the diff."
+wad-image-diff: wad-image-common
+	@echo "Diffing WADs in \"$(WI_LEVELS)\" using git."
+	scripts/wad2image/integration/git-wad-diff.sh "$(WI_COMMIT)" "$(WI_LEVELS)" $(WI_ALL_OPTIONS)
+
+wad-image-help:
+	@echo "Help for wad-image* targets and WI_* variable which can be used to see"
+	@echo "differences between WAD revisions, or to simply view WADs. The following targets"
+	@echo "depend on wad2image being copied or symlinked to the \"scripts\" directory."
+	@echo "Images are created in \"$(WI_IMAGES)\". wad2image can be downloaded"
+	@echo "from http://selliott.org/utilities/wad2image."
+	@echo ""
+	@echo "  Targets:"
+	@echo ""
+	@echo "    wad-image       Generate generate images for WAD files that are in the"
+	@echo "                    workspace."
+	@echo "    wad-image-clean Remove \"$(WI_IMAGES)\" as well as all files in"
+	@echo "                    it."
+	@echo "    wad-image-diff  Use git to generate diff image showing the differences"
+	@echo "                    between two revisions of WAD files. By default the"
+	@echo "                    difference is between latest HEAD and the workspace, but the"
+	@echo "                    WI_COMMIT variable can be used to generate other diffs."
+	@echo "    wad-image-help  This help message."
+	@echo ""
+	@echo "  Variables:"
+	@echo ""
+	@echo "    WI_BW           Make diff images black or white (high contrast) instead of"
+	@echo "                    full color. This applies to wad-image-diff-only."
+	@echo "    WI_CMD          Command used to display images. \"display\" is used by"
+	@echo "                    default. \"animate\" works well for animated GIFs."
+	@echo "    WI_COMMIT       When the wad-image-diff target is invoked this variable"
+	@echo "                    specifies which revisions are compared. It's similar to"
+	@echo "                    git's \"commit\" argument."
+	@echo "    WI_GIF          Create animated GIFs instead of color coded files for the"
+	@echo "                    diff."
+	@echo "    WI_LEVELS       Subdirectory with the level WADs."
+	@echo "    WI_OPTIONS      Additional command line options for wad2image."
+	@echo "    WI_NO_SHOW      If set then don't show the images after creating them."
+	@echo "    WI_PATT         Files patterns that are applied to files in the \"levels\""
+	@echo "                    directory without the \".wad\" suffix. For example,"
+	@echo "                    \"map0*\" to get MAP01 - MAP09. This applies to wad-image"
+	@echo "                    only."
+	@echo "    WI_VERBOSE      If set then make wad2image more verbose."
+	@echo ""
+	@echo "  Examples:"
+	@echo ""
+	@echo "    Verbosely create and display an image for the most recently modified WAD"
+	@echo "    file in \"levels\":"
+	@echo "      make wad-image WI_VERBOSE=t"
+	@echo ""
+	@echo "    Create and display the image for MAP05:"
+	@echo "      make wad-image WI_PATT=map05"
+	@echo ""
+	@echo "    Verbosely create color coded diffs for changed files in the workspace:"
+	@echo "      make wad-image-diff WI_VERBOSE=t"
+	@echo ""
+	@echo "    Same as the above, but with high contrast black or white images:"
+	@echo "      make wad-image-diff WI_VERBOSE=t WI_BW=t"
+	@echo ""
+	@echo "    Same as above, but use animated GIFs to illustrate the diff instead of"
+	@echo "    colors:"
+	@echo "      make wad-image-diff WI_VERBOSE=t WI_GIF=t WI_CMD=animate"
+	@echo ""
+	@echo "    Same as above, but illustrate the diff between two git revisions instead of"
+	@echo "    the workspace:"
+	@echo "      make wad-image-diff WI_VERBOSE=t WI_GIF=t WI_CMD=animate WI_COMMIT=\"0c004ce~..0c004ce\""
 
 %.6:
 	$(MAKE) -C dist man-$*

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,18 @@ WI_ALL_OPTIONS := $(WI_OPTIONS) $(if $(WI_BW), --colors-images bw,) \
     $(if $(WI_IMAGES), --out-dir $(WI_IMAGES),) $(if $(WI_SHOW), -s,) \
     $(if $(WI_VERBOSE), -v,) $(if $(WI_WAD_SPATH), --wad-spath $(WI_WAD_SPATH),)
 wad-image-common:
+ifndef WI_IMAGES
+	$(error WI_IMAGES must be defined)
+endif
+ifndef WI_LEVELS
+	$(error WI_LEVELS must be defined)
+endif
+ifndef WI_SCRIPTS
+	$(error WI_SCRIPTS must be defined)
+endif
+ifndef WI_HOME
+	$(error WI_HOME must be defined)
+endif
 
 # Generating images for WADs in "levels" directory and show the result.
 WI_LATEST := $(shell ls -1t $(WI_LEVELS)/*.wad | head -n 1)
@@ -157,8 +169,12 @@ wad-image-diff: wad-image-common
 wad-image-help: wad-image-common
 	@echo "Help for wad-image* targets and WI_* variable which can be used to see"
 	@echo "differences between WAD revisions, or to simply view WADs. The following targets"
-	@echo "depend on wad2image being copied or symlinked to the \"scripts\" directory."
-	@echo "Images are created in \"$(WI_IMAGES)\". wad2image can be downloaded"
+	@echo "depend on wad2image being installed with bin/wad2image.py in it being in the"
+	@echo "path, or alteratively wad2image being copied or symlinked to the \"$(WI_SCRIPTS)\""
+	@echo "directory. Images are created in \"$(WI_IMAGES)\". Each variable's description"
+	@echo "ends with \"Value:\" followed by that variable's current value. If no variables"
+	@echo "have been specified on the make command line then the value shown is the"
+	@echo "default value. Some variables are unset by default. wad2image can be downloaded"
 	@echo "from http://selliott.org/utilities/wad2image."
 	@echo ""
 	@echo "  Targets:"
@@ -176,31 +192,36 @@ wad-image-help: wad-image-common
 	@echo ""
 	@echo "    WI_BW           Make diff images black or white (high contrast) instead of"
 	@echo "                    full color. This applies to wad-image-diff-only."
-	@echo "    WI_CMD          Command used to display images. \"display\" is used by"
-	@echo "                    default. \"animate\" works well for animated GIFs."
+	@echo "                    Value: $(WI_BW)"
+	@echo "    WI_CMD          Command used to display images. \"display\" is used if no"
+	@echo "                    value is specified. \"animate\" works well for animated"
+	@echo "                    GIFs. Value: $(WI_CMD)"
 	@echo "    WI_COMMIT       When the wad-image-diff target is invoked this variable"
 	@echo "                    specifies which revisions are compared. It's similar to"
-	@echo "                    git's \"commit\" argument."
+	@echo "                    git's \"commit\" argument. Value: $(WI_COMMIT)"
 	@echo "    WI_GIF          Create animated GIFs instead of color coded files for the"
-	@echo "                    diff."
+	@echo "                    diff. Value: $(WI_GIF)"
 	@echo "    WI_HOME         The location where wad2image is installed. By default PATH"
 	@echo "                    is searched for \"wad2image.py\". If it's found the"
 	@echo "                    enclosing installation directory is used. If it's not found"
-	@echo "                    $(WI_SCRIPTS)/wad2image is used."
+	@echo "                    $(WI_SCRIPTS)/wad2image is used. Value: $(WI_HOME)"
 	@echo "    WI_IMAGES       The output directory that will contain the images created."
-	@echo "                    By default images are created in \"wad-images\"."
-	@echo "    WI_LEVELS       Subdirectory with the level WADs."
+	@echo "                    Value: $(WI_IMAGES)"
+	@echo "    WI_LEVELS       Subdirectory with the level WADs. Value: $(WI_IMAGES)"
 	@echo "    WI_OPTIONS      Additional command line options for wad2image."
+	@echo "                    Value: $(WI_OPTIONS)"
 	@echo "    WI_SHOW         If set then show the images after creating them."
-	@echo "    WI_PATT         Files patterns that are applied to files in the \"levels\""
-	@echo "                    directory without the \".wad\" suffix. For example,"
-	@echo "                    \"map0*\" to get MAP01 - MAP09. This applies to wad-image"
-	@echo "                    only."
+	@echo "                    Value: $(WI_SHOW)"
+	@echo "    WI_PATT         Files patterns that are applied to files in the"
+	@echo "                    \"$(WI_LEVELS)\" directory without the \".wad\" suffix. For"
+	@echo "                    example, \"map0*\" to get MAP01 - MAP09. This applies to"
+	@echo "                    wad-image only. Value: $(WI_PATT)"
 	@echo "    WI_VERBOSE      If set then make wad2image more verbose."
+	@echo "                    Value: $(WI_VERBOSE)"
 	@echo "    WI_WAD_SPATH    The search path for WADs where a fully qualified path was"
 	@echo "                    not given. This is typically used for the IWAD. By default"
 	@echo "                    \"wads\" is searched first, so it helps to complete a build"
-	@echo "                    before generating images."
+	@echo "                    before generating images. Value: $(WI_WAD_SPATH)"
 	@echo ""
 	@echo "  Examples:"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -123,13 +123,17 @@ mandir?=/share/man
 waddir?=/share/games/doom
 target=$(DESTDIR)$(prefix)
 
-# Set variables that are common to wad-image* targets.
+# Variables that are common to wad-image* targets.
 WI_LEVELS := levels
 WI_SCRIPTS := scripts
+WI_PATH := $(shell command -v wad2image.py)
+WI_HOME := $(if $(WI_PATH),$(dir $(WI_PATH))..,$(WI_SCRIPTS)/wad2image)
+WI_IMAGES := wad-images
+WI_WAD_SPATH := wads,{top-dir}/wads,.,/usr/share/doom,/usr/local/doom
 WI_ALL_OPTIONS := $(WI_OPTIONS) $(if $(WI_BW), --colors-images bw,) \
     $(if $(WI_CMD), --show-cmd $(WI_CMD),) $(if $(WI_GIF), -d gif,) \
-    $(if $(WI_NO_SHOW),, -s) $(if $(WI_VERBOSE), -v,)
-WI_IMAGES := $(WI_SCRIPTS)/wad2image/images
+    $(if $(WI_IMAGES), --out-dir $(WI_IMAGES),) $(if $(WI_SHOW), -s,) \
+    $(if $(WI_VERBOSE), -v,) $(if $(WI_WAD_SPATH), --wad-spath $(WI_WAD_SPATH),)
 wad-image-common:
 
 # Generating images for WADs in "levels" directory and show the result.
@@ -137,17 +141,20 @@ WI_LATEST := $(shell ls -1t $(WI_LEVELS)/*.wad | head -n 1)
 WI_FILES := $(if $(WI_PATT), $(WI_LEVELS)/$(WI_PATT).wad, $(WI_LATEST))
 wad-image: wad-image-common
 	@echo "Generating images for WADs in \"$(WI_LEVELS)\"."
-	scripts/wad2image/bin/wad2image.py $(WI_ALL_OPTIONS) $(WI_FILES)
+	$(WI_HOME)/bin/wad2image.py $(WI_ALL_OPTIONS) $(WI_FILES)
 
+# Cleanup generated images. Structured this way for safety.
 wad-image-clean: wad-image-common
-	rm -rf $(WI_IMAGES)
+	rm -f $(WI_IMAGES)/*.*
+	-rmdir $(WI_IMAGES)
 
 # Diffing WADs in "levels" using git and show the diff."
 wad-image-diff: wad-image-common
 	@echo "Diffing WADs in \"$(WI_LEVELS)\" using git."
-	scripts/wad2image/integration/git-wad-diff.sh "$(WI_COMMIT)" "$(WI_LEVELS)" $(WI_ALL_OPTIONS)
+	$(WI_HOME)/integration/git-wad-diff.sh "$(WI_COMMIT)" "$(WI_LEVELS)" $(WI_ALL_OPTIONS)
 
-wad-image-help:
+# Help for wad2image.
+wad-image-help: wad-image-common
 	@echo "Help for wad-image* targets and WI_* variable which can be used to see"
 	@echo "differences between WAD revisions, or to simply view WADs. The following targets"
 	@echo "depend on wad2image being copied or symlinked to the \"scripts\" directory."
@@ -158,8 +165,7 @@ wad-image-help:
 	@echo ""
 	@echo "    wad-image       Generate generate images for WAD files that are in the"
 	@echo "                    workspace."
-	@echo "    wad-image-clean Remove \"$(WI_IMAGES)\" as well as all files in"
-	@echo "                    it."
+	@echo "    wad-image-clean Remove \"$(WI_IMAGES)\" as well as all files in it."
 	@echo "    wad-image-diff  Use git to generate diff image showing the differences"
 	@echo "                    between two revisions of WAD files. By default the"
 	@echo "                    difference is between latest HEAD and the workspace, but the"
@@ -177,14 +183,24 @@ wad-image-help:
 	@echo "                    git's \"commit\" argument."
 	@echo "    WI_GIF          Create animated GIFs instead of color coded files for the"
 	@echo "                    diff."
+	@echo "    WI_HOME         The location where wad2image is installed. By default PATH"
+	@echo "                    is searched for \"wad2image.py\". If it's found the"
+	@echo "                    enclosing installation directory is used. If it's not found"
+	@echo "                    $(WI_SCRIPTS)/wad2image is used."
+	@echo "    WI_IMAGES       The output directory that will contain the images created."
+	@echo "                    By default images are created in \"wad-images\"."
 	@echo "    WI_LEVELS       Subdirectory with the level WADs."
 	@echo "    WI_OPTIONS      Additional command line options for wad2image."
-	@echo "    WI_NO_SHOW      If set then don't show the images after creating them."
+	@echo "    WI_SHOW         If set then show the images after creating them."
 	@echo "    WI_PATT         Files patterns that are applied to files in the \"levels\""
 	@echo "                    directory without the \".wad\" suffix. For example,"
 	@echo "                    \"map0*\" to get MAP01 - MAP09. This applies to wad-image"
 	@echo "                    only."
 	@echo "    WI_VERBOSE      If set then make wad2image more verbose."
+	@echo "    WI_WAD_SPATH    The search path for WADs where a fully qualified path was"
+	@echo "                    not given. This is typically used for the IWAD. By default"
+	@echo "                    \"wads\" is searched first, so it helps to complete a build"
+	@echo "                    before generating images."
 	@echo ""
 	@echo "  Examples:"
 	@echo ""
@@ -198,16 +214,22 @@ wad-image-help:
 	@echo "    Verbosely create color coded diffs for changed files in the workspace:"
 	@echo "      make wad-image-diff WI_VERBOSE=t"
 	@echo ""
-	@echo "    Same as the above, but with high contrast black or white images:"
+	@echo "    Same as above but Yadex style (example of WI_OPTIONS):"
+	@echo "      make wad-image-diff WI_VERBOSE=t WI_OPTIONS=\"-c yadex\""
+	@echo ""
+	@echo "    Same as the above, but with high contrast black or white images, but"
+	@echo "      without Yadex style:"
 	@echo "      make wad-image-diff WI_VERBOSE=t WI_BW=t"
 	@echo ""
 	@echo "    Same as above, but use animated GIFs to illustrate the diff instead of"
-	@echo "    colors:"
-	@echo "      make wad-image-diff WI_VERBOSE=t WI_GIF=t WI_CMD=animate"
+	@echo "    colors. Also, once the animated GIFs are created they'll be shown with"
+	@echo "    the \"animate\" command:"
+	@echo "      make wad-image-diff WI_VERBOSE=t WI_GIF=t WI_SHOW=t WI_CMD=animate"
 	@echo ""
 	@echo "    Same as above, but illustrate the diff between two git revisions instead of"
 	@echo "    the workspace:"
-	@echo "      make wad-image-diff WI_VERBOSE=t WI_GIF=t WI_CMD=animate WI_COMMIT=\"0c004ce~..0c004ce\""
+	@echo "      make wad-image-diff WI_VERBOSE=t WI_GIF=t WI_SHOW=t WI_CMD=animate \
+WI_COMMIT=\"0c004ce~..0c004ce\""
 
 %.6:
 	$(MAKE) -C dist man-$*


### PR DESCRIPTION
This is an updated and significantly changed attempt to integrate wad2image into the Freedoom build. Some highlights since the last pull request I submitted (#432):

- Moved most functionality into wad2image. For example, my previous pull request added scripts to the "scripts" directory. The new approach is for wad2image to be copied to or symlinked to the "scripts" directory, but otherwise there are no new scripts.
- In addition to animated GIFs and the black or white images seen in my [Freedoom forum post](https://www.doomworld.com/forum/topic/93601-ive-created-a-utility-that-displays-differences-in-wad-revisions-visually/) color coded difference images can be generated on top of reduced color saturation images. I've added an example to [wad2image's home page](http://selliott.org/utilities/wad2image).
- More flexible make targets to generate images from the build.
- Various wad2image bug fixes.

The latest version of wad2image (0.9.3) is needed. I think it makes sense to refer to it with a [latest link](http://selliott.org/sites/default/files/utilities/wad2image/wad2image-latest.zip).

I'm curious how you feel about the size of "Makefile" being increased by 88 lines mostly for help. I can move that to a separate text file, but I figured it might be handy to have a help build target.