### PR TITLE
textures: Don't include sprites in pnames list.

### DIFF
--- a/lumps/textures/Makefile
+++ b/lumps/textures/Makefile
@@ -12,7 +12,8 @@ phase1/texture1.lmp: textures.cfg
 	                 -output_texture1=phase1/texture1.lmp    \
 	                 -output_texture2=phase1/texture2.lmp    \
 	                 -output_pnames=phase1/pnames.lmp        \
-	                 -output_pnames_txt=phase1/pnames.txt
+	                 -output_pnames_txt=phase1/pnames.txt    \
+	                 -sprites_dir=../../sprites
 	cp phase1/texture1.lmp ../fd1txtr1.lmp
 	cp phase1/texture2.lmp ../fd1txtr2.lmp
 	cp phase1/pnames.lmp   ../fd1pname.lmp
@@ -23,7 +24,8 @@ phase2/texture1.lmp: textures.cfg
 	                 -compat_pnames=doom2/pnames.txt         \
 	                 -output_texture1=phase2/texture1.lmp    \
 	                 -output_pnames=phase2/pnames.lmp        \
-	                 -output_pnames_txt=phase2/pnames.txt
+	                 -output_pnames_txt=phase2/pnames.txt    \
+	                 -sprites_dir=../../sprites
 	cp phase2/texture1.lmp ../fd2txtr1.lmp
 	cp phase2/pnames.lmp   ../fd2pname.lmp
 
@@ -33,7 +35,8 @@ freedm/texture1.lmp: textures.cfg
 	                 -compat_pnames=doom2/pnames.txt         \
 	                 -output_texture1=freedm/texture1.lmp    \
 	                 -output_pnames=freedm/pnames.lmp        \
-	                 -output_pnames_txt=freedm/pnames.txt
+	                 -output_pnames_txt=freedm/pnames.txt    \
+	                 -sprites_dir=../../sprites
 	cp freedm/texture1.lmp ../fdmtxtr1.lmp
 	cp freedm/pnames.lmp   ../fdmpname.lmp
 

--- a/lumps/textures/build-textures
+++ b/lumps/textures/build-textures
@@ -34,6 +34,7 @@
 # Freedoom IWADs cannot be built in parallel by make.
 
 import collections
+import os.path
 import re
 import sys
 import struct
@@ -161,16 +162,22 @@ def read_names_file(filename):
 				result.append(line.upper())
 		return result
 
-def write_names_file(names, filename):
+def write_names_file(names, filename, sprites_dir):
 	"""Write a list of names to a file.
 
 	Args:
 	  names: List of names to write.
 	  filename: Filename to write them to.
+	  sprites_dir: Path to directory containing sprites. If a file is found
+	      in this directory matching a patch name, that patch will not be
+	      included in the outputted list.
 	"""
 	with open(filename, "w") as f:
 		for name in names:
-			f.write("%s\n" % name)
+			filename = "%s.png" % name.lower()
+			sprite_path = os.path.join(sprites_dir, filename)
+			if not os.path.exists(sprite_path):
+				f.write("%s\n" % name)
 
 def load_compat_textures(textures, compat_file):
 	"""Pre-populate a texture set from a compatibility file.
@@ -264,6 +271,9 @@ Full list of arguments:
   -output_texture2: Path to the TEXTURE2 lump to generate.
   -output_pnames: Path to the PNAMES lump to generate (required).
   -output_pnames_txt: Path to a text file to save a list of PNAMES.
+  -sprites_dir: Path to the sprites directory, used to identify patches which
+      are actually embedded sprites. These sprites will not be included in the
+      outputted pnames file.
   -compat_texture1: File containing compatibility list of TEXTURE1 textures
   -compat_texture2: File containing compatibility list of TEXTURE2 textures
   -compat_pnames: File containing compatibility list of PNAMES
@@ -282,7 +292,7 @@ def parse_command_line(args):
 	# Parse command line:
 	valid_args = ("compat_texture1", "compat_texture2", "compat_pnames",
 	              "output_texture1", "output_texture2", "output_pnames",
-	              "output_pnames_txt")
+	              "output_pnames_txt", "sprites_dir")
 	result = {arg: None for arg in valid_args}
 
 	for arg in args:
@@ -339,5 +349,6 @@ if args["output_texture2"]:
 	texture2.write_texture_lump(args["output_texture2"])
 write_pnames_lump(pnames, args["output_pnames"])
 if args["output_pnames_txt"]:
-	write_names_file(sorted(pnames), args["output_pnames_txt"])
+	write_names_file(sorted(pnames), args["output_pnames_txt"],
+	                 args["sprites_dir"])
 


### PR DESCRIPTION
A useful vanilla-compatible trick is that it's possible to include
sprites as patches inside texture definitions. It turns out that
both Final Doom IWADs added textures which do this, and Freedoom
inherits this as a result. We shouldn't include these sprites in the
pnames.txt that gets generated for inclusion in wadinfo.txt, since
they're already defined in wadinfo.txt under [sprites] and won't
be found under patches/ anyway.

This should help as a step towards resolving #485.