### PR TITLE
Improved wad2image top level directory determination.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,8 @@ target=$(DESTDIR)$(prefix)
 WI_LEVELS := levels
 WI_SCRIPTS := scripts
 WI_PATH := $(shell command -v wad2image.py)
-WI_HOME := $(if $(WI_PATH),$(dir $(WI_PATH))..,$(WI_SCRIPTS)/wad2image)
+WI_HOME := $(if $(WAD2IMAGE_HOME),$(WAD2IMAGE_HOME),$(if $(WI_PATH),$(shell $(WI_PATH) \
+    --get-top-dir),$(WI_SCRIPTS)/wad2image))
 WI_IMAGES := wad-images
 WI_WAD_SPATH := wads,{top-dir}/wads,.,/usr/share/doom,/usr/local/doom
 WI_ALL_OPTIONS := $(WI_OPTIONS) $(if $(WI_BW), --colors-images bw,) \


### PR DESCRIPTION
Unfortunately for the previous pull request (#480)  the logic to find the top level directory for wad2image did not work as well as I hoped. It's particularly a problem for the `wad-image-diff` targets where the `git-wad-diff.sh` script is used as that bash script is not as sophisticated as `wad2image.py` for finding the top level directory. To address this I just created a new version of wad2image (version 0.9.5) that has a new command line option `--get-top-dir` so that `git-wad-diff.sh` can benefit from that logic.

The small fix to `Makefile` is to use the top level directory that `wad2image.py` says rather than attempting to calculate it based on the path.

I've made sure all of the examples shown by `wad-image-help` work for the following:

- wad2image is symlinked to the `scripts` directory.
- `wad2image.py` in the expanded ZIP is in `PATH`.
- `wad2image.py` is symlinked into the `PATH` (to a target directory such as `/usr/local/bin`).
- `WAD2IMAGE_HOME` is set to the top level directory.

Hopefully that's it for wad2image for a while, unless there's a feature you want.