### PR TITLE
dehacked: Turn on full brightness for a few frames

### DIFF
--- a/lumps/dehacked.lmp
+++ b/lumps/dehacked.lmp
@@ -4,6 +4,25 @@ Patch format = 6
 
 # SPDX-License-Identifier: BSD-3-Clause
 
+# The following changes turn on full brightness for a few firing frames,
+# since these they show gun flashes and it looks weird if they aren't full
+# brightness. Doom itself has this problem too but it's more noticeable with
+# the Freedoom sprites.
+
+# Zombie
+Frame 185
+Sprite subnumber = 32773
+
+# Assault tripod
+Frame 685
+Sprite subnumber = 32773
+
+Frame 687
+Sprite subnumber = 32773
+
+Frame 689
+Sprite subnumber = 32773
+
 # This is a magic comment recognized by Chocolate Doom, so that the
 # BEX [STRINGS] section below will be parsed:
 #

--- a/lumps/dehacked.lmp
+++ b/lumps/dehacked.lmp
@@ -13,6 +13,10 @@ Patch format = 6
 Frame 185
 Sprite subnumber = 32773
 
+# Minigun zombie
+Frame 419
+Sprite subnumber = 32773
+
 # Assault tripod
 Frame 685
 Sprite subnumber = 32773


### PR DESCRIPTION
The firing frames for the zombie and assault tripod look weird if they're not 
shown in full brightness, so add a dehacked tweak to set them to full
brightness. Doom has the same bug but it isn't quite as noticeable.

This could theoretically cause a mod compatibility issue since unexpected
frames might be fully lit. However, (1) the worst that can happen is a minor
cosmetic issue, and (2) I don't know of any actual mods this affects (maybe
there aren't any). I think the benefit outweighs the potential downside.