### PR TITLE
Add "hexdump" diff documentation and instructions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 # Auto detect text files and perform LF normalization
 * text eol=lf
 
+# Append "diff=hexdump" to one of the following to enable binary
+# diffs for that file type.
 *.png -text
 *.wad -text
 *.wav -text

--- a/README.adoc
+++ b/README.adoc
@@ -274,3 +274,21 @@ writing (February 2017), core Git does not yet have a mechanism to
 output this format, but you may use a
 https://gist.github.com/chungy/195f53bfb9253584e596[shell script] and
 place it in your `$PATH` to achieve some ease in generating them.
+
+By default for binary files `git diff` only notes differences instead
+of displaying them. In some cases, such as when a small part of a
+binary file has changed without otherwise shifting the bytes, it can
+be helpful to display differences in binary files using `hexdump`.
+To enable `hexdump` diffs for binary files:
+
+  * Make sure `hexdump` (Linux) or `hexdump.exe` (Windows) is in your
+    path. On Linux this may mean installing the `hexdump` or
+    `util-linux` package.
+  * Edit your `.gitconfig` file and add a `[diff "hexdump"]` section
+    that contains `textconv = hexdump -C`.
+  * Edit Freedoom's `.gitattributes` file and add `diff=hexdump` for
+    the binary file type that you want to see diffs for.
+
+Now `git diff` will display differences for that binary file type. To
+restore the default diffing behavior revert the changes made to
+Freedoom's `.gitattributes`.


### PR DESCRIPTION
In order to assist with diffing binary files, particularly WAD files,
instructions and comments have been added in order to assist with
diffing binary files with the "hexdump" tool.

This can be thought of as a companion to PR 481 since that change introduces binary changes where diffing with "hexdump" works well.

I did this because figuring out how to do custom diffing in git is not obvious. If you think it's too verbose then feel free to close it out. You can still refer back to this if you ever want to do it.