### PR TITLE
Updated README How To Play with link to android Freedoom app

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ or your home directory.  If _Freedoom_ comes packaged as part of your
 operating system distribution, it should already be installed into the
 proper location.
 
-On Android, Freedoom is included in the https://github.com/mkrupczak3/GZDoom-Android[Freedoom app] and https://play.google.com/store/apps/details?id=com.opentouchgaming.deltatouch&hl=en_US[Delta Touch]
+On Android, Freedoom is included in the https://github.com/mkrupczak3/GZDoom-Android[Freedoom app]
 
 If you wish to venture outside of GZDoom, beware that _Phase 1_ and
 _Phase 2_ require a https://doomwiki.org/wiki/Limit_removing[limit

--- a/README.adoc
+++ b/README.adoc
@@ -55,6 +55,8 @@ or your home directory.  If _Freedoom_ comes packaged as part of your
 operating system distribution, it should already be installed into the
 proper location.
 
+On Android, Freedoom is included in the https://github.com/mkrupczak3/GZDoom-Android[Freedoom app] and https://play.google.com/store/apps/details?id=com.opentouchgaming.deltatouch&hl=en_US[Delta Touch]
+
 If you wish to venture outside of GZDoom, beware that _Phase 1_ and
 _Phase 2_ require a https://doomwiki.org/wiki/Limit_removing[limit
 removing] engine, which is thankfully the majority of them, but


### PR DESCRIPTION
Updated the README "How To Play" section with links to the [Freedoom android app GitHub page](https://github.com/mkrupczak3/GZDoom-Android) and the Delta Touch Google Play [store listing](https://play.google.com/store/apps/details?id=com.opentouchgaming.deltatouch)