### PR TITLE
dist: Add releases and content rating to AppStream metadata

### DIFF
--- a/dist/freedm.appdata.xml
+++ b/dist/freedm.appdata.xml
@@ -43,4 +43,10 @@
       <caption>DM18: Energy Facility</caption>
     </screenshot>
   </screenshots>
+  <releases>
+    <release version="0.11.3" date="2017-07-18"></release>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+  </content_rating>
 </component>

--- a/dist/freedoom1.appdata.xml
+++ b/dist/freedoom1.appdata.xml
@@ -43,4 +43,10 @@
       <caption>C2M2: Power Plant</caption>
     </screenshot>
   </screenshots>
+  <releases>
+    <release version="0.11.3" date="2017-07-18"></release>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+  </content_rating>
 </component>

--- a/dist/freedoom2.appdata.xml
+++ b/dist/freedoom2.appdata.xml
@@ -42,4 +42,10 @@
       <caption>MAP09: Datacenter</caption>
     </screenshot>
   </screenshots>
+  <releases>
+    <release version="0.11.3" date="2017-07-18"></release>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+  </content_rating>
 </component>


### PR DESCRIPTION
Those tags are now required by Flathub.

This closes #522.