### PR TITLE
dehacked: Use three periods instead of a comma

### DIFF
--- a/lumps/dehacked.lmp
+++ b/lumps/dehacked.lmp
@@ -398,7 +398,7 @@ E3TEXT = The abomination explodes into\n\
 E4TEXT = Despite fighting an army of monsters,\n\
          you managed to find a ship here.\n\
          Looks like freedom is yours.\n\n\
-         "Time to get out of here,"\n\
+         "Time to get out of here..."\n\
          you tell yourself and plump down\n\
          on the comfortable chair.\n\n\
          The ship rumbles as she wakes up.\n\


### PR DESCRIPTION
Use three periods instead of a comma for the inner monologue, as this helps make the text flow a bit better.