### PR TITLE
Fixes to the skill levels

### DIFF
--- a/graphics/text/config.py
+++ b/graphics/text/config.py
@@ -105,8 +105,8 @@ red_graphics = {
 	'm_jkill': 'Please don\'t kill me!',
 	'm_rough': 'Will this hurt?',
 	'm_hurt': 'Bring on the pain.',
-	'm_ultra': 'Extreme Carnage',
-	'm_nmare': 'INSANITY!',
+	'm_ultra': 'Extreme Carnage.',
+	'm_nmare': 'MAYHEM!',
 
 	'm_lgttl': 'LOAD GAME',
 	'm_sgttl': 'SAVE GAME',

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -89,9 +89,9 @@ effectively the same as _Will This Hurt?_, except that damage is halved.
 | 2 | **Will This Hurt?** | Easy skill level, a good choice if you're
 finding _Bring on the Pain_ too challenging.
 | 3 | **Bring on the Pain.** | The default skill level.
-| 4 | **Extreme Carnage** | A more challenging skill level, suited more
+| 4 | **Extreme Carnage.** | A more challenging skill level, suited more
 for experienced players and people in search of a challenge.
-| 5 | **INSANITY!** | **Not Recommended**. This is equivalent to
+| 5 | **MAYHEM!** | **Not Recommended**. This is equivalent to
 _Extreme Carnage_ except that monster attacks are up to twice as fast,
 and killed monsters come back to life after around 40 seconds.
 |==========================


### PR DESCRIPTION
Extreme Carnage should have a period to be consistent with the other skills. Yes, I know the previous labels are full sentences, but given we all know the final skill must end with a ! it does end up being left as the only unpunctuated one.

I'm starting to dislike "INSANITY!" for multiple reasons, but it also seems kinda flat and uninspired after decades of eXtReMe / "totally random crazy monkey spork uwu" whatever in popular culture.

"Mayhem" might be a better descriptor anyway for the additional speed and damage and randomly respawning monsters.