### PR TITLE
dist/freedoom: Set DOOMWADPATH with sensible default value if unset

### DIFF
--- a/dist/freedoom
+++ b/dist/freedoom
@@ -31,6 +31,10 @@ case "$(basename "$0")" in
         ;;
 esac
 
+if [ -z "$DOOMWADPATH" ]; then
+    export DOOMWADPATH="/usr/share/doom:/usr/share/games/doom:/usr/local/share/doom:/usr/local/share/games/doom"
+fi
+
 if [ -z "$DOOMPORT" ] && [ -h "$HOME"/.doomport ]; then
     if [ -f "$(readlink -f "$HOME"/.doomport)" ] \
         && [ -x "$(readlink -f "$HOME"/.doomport)" ]; then


### PR DESCRIPTION
Engines such as Odamex may not have a default search path and simply
search for freedoom1.wad relative to the current directory. This can
cause an unexpected WAD file not found error when executing the freedoom
script.

This issue is mitigated by setting a default DOOMWADPATH environment
variable with sensible search paths, if it is not already set. All
engines listed in the PORTS variable support the DOOMWADPATH environment
variable, which makes it a simple and convenient way of helping prevent
this error.