### PR TITLE
textures: Add a STARBR1 texture.

### DIFF
--- a/lumps/textures/textures.cfg
+++ b/lumps/textures/textures.cfg
@@ -2235,6 +2235,9 @@ SLADPOIS        64      128
 *   PS20A0      1       49
 SLADWALL        64      128
 *   WLA128_1    0       0
+STARBR1         64      128
+*   SW11_4      0       0
+*   SW11_5      32      0
 STARBR2         128     128
 *   SW16_4      32      0
 *   SW15_4      0       0


### PR DESCRIPTION
Weirdly there's a STARBR2 but no STARBR1, and there are also these
SW11_4 and SW11_5 patches which are not used in anything except for
in COMPUTE3 as part of a montage texture. It seems like a natural fit.