### PR TITLE
Makefile: Explicitly define the shell (bash) and its env.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
+SHELL=bash -Eeuxo pipefail
 VERSION=$(shell git describe --abbrev=8 --dirty 2>/dev/null || echo v0.12.1)
 WADS=wads
 ASCIIDOC=asciidoc


### PR DESCRIPTION
This makes the "command: command not found" error no longer occur on
systems where the default shell is not `bash`, or does not support the
`bash` builtins. Additionally, a sane environment is set for safer
shell command use and scripting.

The environment settings for `bash` here do the following:
  - Terminate on errors, including signal `ERR` traps. (-e, -E)
  - Ensure that shell variables are set before use. (-u)
  - Print the shell command, and arguments, as they're run. (-x)
  - Fail on errors in any command in a pipeline. (-o pipefail)