### PR TITLE
Update manual with "Contributing to Freedoom" section and a 'tactical tip' for the angle grinder

### DIFF
--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -571,11 +571,13 @@ suggestions:
   effectively, they’ll spend their energy killing each other and you’ll save
   on ammunition.
   
-* If you encounter a horde of flesh worms or stealth worms, The chainsaw is a
-  great weapon to use. Worms can't attack while being sawed, and if you back 
-  into a corner that is "107 degrees or narrower", they can only come at you 
-  one at a time. The chainsaw also works well on Trilobites: they can't attack
-  while taking damage from the chainsaw.
+* If you encounter a horde of flesh worms or stealth worms, The angle grinder is a
+  great weapon to use both to conserve ammo and avoid taking damage.
+  Worms can't attack while being sawed, and if you back 
+  into a corner that is at only as wide as or narrower than about a right angle,
+  they can only come at you 
+  one at a time. The angle grinder also works well on Trilobites: they can't attack
+  while taking damage from it.
 
 <<<
 
@@ -672,8 +674,9 @@ provided that https://github.com/freedoom/freedoom/blob/master/COPYING.adoc[cert
 are met.
 
 If you'd like to contribute to the Freedoom project, please check out the 
-https://github.com/freedoom/freedoom/[project's page] and
-https://www.doomworld.com/forum/17-freedoom/[discussion forum].
+https://github.com/freedoom/freedoom/[project's page],
+https://www.doomworld.com/forum/17-freedoom/[discussion forum],
+and https://discord.gg/9DA3fut[discord chat].
 
 https://help.github.com/en/github[How to use Git version control for contributions]
 

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -634,19 +634,6 @@ on five star rankings by visitors to the site.
 
 <<<
 
-// == Contributing to Freedoom ==
-
-// TODO: Write this section.
-
-// <<<
-
-// [[reusing]]
-// == Reusing portions of Freedoom ==
-
-// TODO: Write this section.
-
-// <<<
-
 == Cheats ==
 
 If you’re finding the game too difficult, you can always try playing at
@@ -671,3 +658,32 @@ number of cheats that you can turn to:
 | **IDBEHOLDM** | Gives the tactical survey map.
 | **IDBEHOLDL** | Gives the night vision goggles.
 |==========================
+
+<<<
+
+== Contributing to Freedoom ==
+
+Freedoom is a 
+[free and open source software (FOSS)]https://en.wikipedia.org/wiki/Free_and_open-source_software
+project contributed to by many users around the world. It is available as 
+both free in cost (free as in free beer) and in modification and 
+redistribution rights (free as in free speech) to end users,
+provided that [certain requirenments]https://github.com/freedoom/freedoom/blob/master/COPYING.adoc
+are met.
+
+If you'd like to contribute to the Freedoom project, please check out the 
+[project's page]https://github.com/freedoom/freedoom/ and
+[discussion forum]https://www.doomworld.com/forum/17-freedoom/
+
+[How to use Git version control for contributions]https://help.github.com/en/github
+
+<<<
+
+[[reusing]]
+== Reusing portions of Freedoom ==
+
+Since [Freedoom is free]https://freedoom.github.io/about.html, some other
+projects have used Freedoom's assets.  We think this is a great use of the 
+project and should be encouraged. If you use portions of Freedoom in your
+project, please let us know by filing an issue or pull request on
+[Freedoom's website project page]https://github.com/freedoom/freedoom.github.io

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -576,7 +576,7 @@ suggestions:
   Worms can't attack while being sawed, and if you back 
   into any corner that is roughly as wide as or narrower than a right angle,
   they can only come at you 
-  one at a time. The angle grinder also works well on Trilobites: they can't attack
+  one at a time. The angle grinder also works well on trilobites: they can't attack
   while taking damage from it.
 
 <<<
@@ -666,15 +666,15 @@ number of cheats that you can turn to:
 == Contributing to Freedoom ==
 
 Freedoom is a 
-https://en.wikipedia.org/wiki/Free_and_open-source_software[free and open source software (FOSS)]
+https://www.gnu.org/philosophy/free-sw.html[free content]
 project contributed to by many users around the world. It is available as 
 both free in cost (free as in free beer) and in modification and 
 redistribution rights (free as in free speech) to end users,
-provided that https://github.com/freedoom/freedoom/blob/master/COPYING.adoc[certain requirenments]
-are met.
+provided that the original software license is included and/or 
+viewable by users of modified versions.
 
 If you'd like to contribute to the Freedoom project, please check out the 
-https://github.com/freedoom/freedoom/[project's page],
+https://github.com/freedoom/freedoom[project's page],
 https://www.doomworld.com/forum/17-freedoom/[discussion forum],
 and https://discord.gg/9DA3fut[discord chat].
 

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -574,7 +574,7 @@ suggestions:
 * If you encounter a horde of flesh worms or stealth worms, The angle grinder is a
   great weapon to use both to conserve ammo and avoid taking damage.
   Worms can't attack while being sawed, and if you back 
-  into any corner that is at roughly as wide as or narrower than a right angle,
+  into any corner that is roughly as wide as or narrower than a right angle,
   they can only come at you 
   one at a time. The angle grinder also works well on Trilobites: they can't attack
   while taking damage from it.

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -671,7 +671,7 @@ project contributed to by many users around the world. It is available as
 both free in cost (free as in free beer) and in modification and 
 redistribution rights (free as in free speech) to end users,
 provided that the original software license is included and/or 
-viewable by users of modified versions.
+viewable by users of modified or redistributed versions.
 
 If you'd like to contribute to the Freedoom project, please check out the 
 https://github.com/freedoom/freedoom[project's page],

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -680,6 +680,7 @@ and https://discord.gg/9DA3fut[discord chat].
 
 https://help.github.com/en/github[How to use Git version control for contributions]
 
+https://guides.github.com/activities/forking/[How to fork a project and create a pull request with Git]
 <<<
 
 [[reusing]]

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -574,7 +574,7 @@ suggestions:
 * If you encounter a horde of flesh worms or stealth worms, The angle grinder is a
   great weapon to use both to conserve ammo and avoid taking damage.
   Worms can't attack while being sawed, and if you back 
-  into a corner that is at only as wide as or narrower than about a right angle,
+  into any corner that is at roughly as wide as or narrower than a right angle,
   they can only come at you 
   one at a time. The angle grinder also works well on Trilobites: they can't attack
   while taking damage from it.

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -570,6 +570,12 @@ suggestions:
   easier for you to target. It also encourages monster in-fighting; if done
   effectively, they’ll spend their energy killing each other and you’ll save
   on ammunition.
+  
+* If you encounter a horde of flesh worms or stealth worms, The chainsaw is a
+  great weapon to use. Worms can't attack while being sawed, and if you back 
+  into a corner that is "107 degrees or narrower", they can only come at you 
+  one at a time. The chainsaw also works well on Trilobites: they can't attack
+  while taking damage from the chainsaw.
 
 <<<
 

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -681,6 +681,7 @@ and https://discord.gg/9DA3fut[discord chat].
 https://help.github.com/en/github[How to use Git version control for contributions]
 
 https://guides.github.com/activities/forking/[How to fork a project and create a pull request with Git]
+
 <<<
 
 [[reusing]]

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -673,7 +673,7 @@ are met.
 
 If you'd like to contribute to the Freedoom project, please check out the 
 https://github.com/freedoom/freedoom/[project's page] and
-https://www.doomworld.com/forum/17-freedoom/[discussion forum]
+https://www.doomworld.com/forum/17-freedoom/[discussion forum].
 
 https://help.github.com/en/github[How to use Git version control for contributions]
 

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -664,26 +664,26 @@ number of cheats that you can turn to:
 == Contributing to Freedoom ==
 
 Freedoom is a 
-[free and open source software (FOSS)]https://en.wikipedia.org/wiki/Free_and_open-source_software
+https://en.wikipedia.org/wiki/Free_and_open-source_software[free and open source software (FOSS)]
 project contributed to by many users around the world. It is available as 
 both free in cost (free as in free beer) and in modification and 
 redistribution rights (free as in free speech) to end users,
-provided that [certain requirenments]https://github.com/freedoom/freedoom/blob/master/COPYING.adoc
+provided that https://github.com/freedoom/freedoom/blob/master/COPYING.adoc[certain requirenments]
 are met.
 
 If you'd like to contribute to the Freedoom project, please check out the 
-[project's page]https://github.com/freedoom/freedoom/ and
-[discussion forum]https://www.doomworld.com/forum/17-freedoom/
+https://github.com/freedoom/freedoom/[project's page] and
+https://www.doomworld.com/forum/17-freedoom/[discussion forum]
 
-[How to use Git version control for contributions]https://help.github.com/en/github
+https://help.github.com/en/github[How to use Git version control for contributions]
 
 <<<
 
 [[reusing]]
 == Reusing portions of Freedoom ==
 
-Since [Freedoom is free]https://freedoom.github.io/about.html, some other
+Since https://freedoom.github.io/about.html[Freedoom is free], some other
 projects have used Freedoom's assets.  We think this is a great use of the 
 project and should be encouraged. If you use portions of Freedoom in your
 project, please let us know by filing an issue or pull request on
-[Freedoom's website project page]https://github.com/freedoom/freedoom.github.io
+https://github.com/freedoom/freedoom.github.io[Freedoom's website project page]


### PR DESCRIPTION
[Link to viewable Adoc
](https://github.com/mkrupczak3/freedoom/blob/master/manual/manual.adoc)

Changes:
* Add a "contributing" section which explains how Freedoom is free and open source (free as in free beer and free as in free speech), and provides links to the project's GitHub page, the Doomworld forums, the Freedoom discord, and the help articles on GitHub for how to get started working with git

* Add a tactical tip for using the angle grinder to take care of flesh worms and Trilobites

Tactical Tip:

If you encounter a horde of flesh worms or stealth worms, The angle grinder is a great weapon to use both to conserve ammo and avoid taking damage. Worms can’t attack while being sawed, and if you back into any corner that is roughly as wide as or narrower than a right angle, they can only come at you one at a time. The angle grinder also works well on Trilobites: they can’t attack while taking damage from it.

