### PR TITLE
Add Continuous Integration

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -9,21 +9,48 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Get full repository history
+      run: |
+        git remote add freedoom https://github.com/freedoom/freedoom.git
+        git fetch --all
+    - name: Install Prerequisites
+      run: |
+        sudo apt update
+        sudo apt install python3-pil asciidoc unzip zip ruby dos2unix
+        sudo gem install asciidoctor-pdf --pre
     - name: Install Deutex
       run: |
         git clone https://github.com/Doom-Utils/deutex.git
         cd deutex
+        git checkout v5.2.1
         sudo apt install libpng-dev
         ./bootstrap
         ./configure
         make
         sudo make install
     - name: Build
+      id: buildstep
       run: |
-        sudo apt install python3-pil
-        PATH=/usr/games:$PATH make
-    - name: Upload Package
+        make dist
+        mkdir -p artifacts/freedoom
+        mkdir -p artifacts/freedm
+        unzip wads/freedoom-*.zip -d artifacts/freedoom
+        unzip wads/freedm-*.zip -d artifacts/freedm
+        export VERSION=$(git describe --abbrev=8)
+        if [[ ${VERSION:0:1} == "v" ]]; then
+          export VERSION=${VERSION:1}
+        fi
+        echo "::set-output name=VERSION::$VERSION"
+    - name: Upload Freedoom
       uses: actions/upload-artifact@v1
       with:
-        path: "./wads"
-        name: "wads"
+        path: "artifacts/freedoom"
+        name: freedoom-${{steps.buildstep.outputs.VERSION}}
+    - name: Upload Freedm
+      uses: actions/upload-artifact@v1
+      with:
+        path: "artifacts/freedm"
+        name: freedm-${{steps.buildstep.outputs.VERSION}}
+

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,29 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Deutex
+      run: |
+        git clone https://github.com/Doom-Utils/deutex.git
+        cd deutex
+        sudo apt install libpng-dev
+        ./bootstrap
+        ./configure
+        make
+        sudo make install
+    - name: Build
+      run: |
+        sudo apt install python3-pil
+        PATH=/usr/games:$PATH make
+    - name: Upload Package
+      uses: actions/upload-artifact@v1
+      with:
+        path: "./wads"
+        name: "wads"


### PR DESCRIPTION
Uses Github Actions to run `make` and upload the build artifacts