### PR TITLE
dist: Request dedicated GPU when starting Freedoom from `.desktop` file

### DIFF
--- a/dist/io.github.freedoom.FreeDM.desktop
+++ b/dist/io.github.freedoom.FreeDM.desktop
@@ -5,6 +5,7 @@ Comment[he]=הילחם בחברים ובאויבים בקרבות מיתה תח�
 GenericName=First Person Shooter Game
 GenericName[he]=משחק יריות בגוף ראשון
 Type=Application
+PrefersNonDefaultGPU=true
 Icon=io.github.freedoom.FreeDM
 Keywords=first;person;shooter;doom;freedoom;
 Categories=Game;ActionGame;

--- a/dist/io.github.freedoom.Phase1.desktop
+++ b/dist/io.github.freedoom.Phase1.desktop
@@ -6,6 +6,7 @@ Comment[he]=הילחם במפלצות בארבעה פרקים בעלי 9 שלב�
 GenericName=First Person Shooter Game
 GenericName[he]=משחק יריות בגוף ראשון
 Type=Application
+PrefersNonDefaultGPU=true
 Icon=io.github.freedoom.Phase1
 Keywords=first;person;shooter;doom;freedoom;
 Categories=Game;ActionGame;

--- a/dist/io.github.freedoom.Phase2.desktop
+++ b/dist/io.github.freedoom.Phase2.desktop
@@ -6,6 +6,7 @@ Comment[he]=הילחם במפלצות בפרק אדיר אחד בעל 32 שלב�
 GenericName=First Person Shooter Game
 GenericName[he]=משחק יריות בגוף ראשון
 Type=Application
+PrefersNonDefaultGPU=true
 Icon=io.github.freedoom.Phase2
 Keywords=first;person;shooter;doom;freedoom;
 Categories=Game;ActionGame;


### PR DESCRIPTION
See <https://www.hadess.net/2020/05/dual-gpu-support-launch-on-discrete-gpu.html> for more information about this newly added `.desktop` entry property.