### PR TITLE
CREDITS: Add contributors since v0.12.1

### DIFF
--- a/BUILD-SYSTEM.adoc
+++ b/BUILD-SYSTEM.adoc
@@ -265,5 +265,5 @@ ZenNode when it's not in the path and to rebuild only the first
 episode of Freedoom 1 as well all of the deathmatch levels:
 [source,bash]
 -----------------
-make NODE_BUILDER=/opt/zennode/ZenNode NODE_BUILDER_LEVELS="c1m? dm??" rebuild-nodes
+make NODE_BUILDER=/opt/zennode/ZenNode NODE_BUILDER_LEVELS="e1m? dm??" rebuild-nodes
 -----------------

--- a/CREDITS
+++ b/CREDITS
@@ -384,9 +384,9 @@ D: sprites
 
 N: Simon Howard
 S: fraggle
-E: idgames@soulsphere.org
+E: fraggle@soulsphere.org
 W: https://soulsphere.org
-D: project admin, scripting and build system, textures, sprites
+D: project admin, scripting, build system, textures, sprites, graphics, lumps, manual, patches
 
 N: Joe Dowland
 E: jon+joefreedoom@alcopop.org
@@ -820,7 +820,7 @@ D: sprites: Zombieman/Shotgunners boots update
 
 S: Korp
 E: korpkat@gmail.com
-D: Sprites, Textures and Musics
+D: Sprites, Textures, Musics, buildcfg.txt, patches
 
 S: ajanddino
 N: Anthony Pierce
@@ -831,4 +831,91 @@ N: Jaden LeMieux
 S: i"Red"MC
 E: jadenquinn8@hotmail.com
 D: Map balancing fixes, C3M4
+
+S: /dev/urandom
+E: dev.urandom@posteo.org
+D: graphics, patches, sprites
+
+S: AerialB
+D: COPYING.adoc
+
+S: basedSkeleton
+D: sprites
+
+S: boogiebogus
+D: buildcfg.txt, sprites
+
+S: Chexter
+D: patches
+
+S: ConsumingCritic
+D: levels
+
+S: Eonfge
+E: contact@kevindegeling.nl
+D: dist
+
+N: Erick Tenorio
+S: guynamederick
+E: guynamederick@gmail.com
+D: levels, lumps, sounds
+
+N: Fabian Greffrath
+E: fabian@greffrath.com
+D: buildcfg.txt, graphics
+
+S: HorroMovieGuy
+D: buildcfg.txt, lumps, manual, sounds, sprites
+
+N: Hugo Locurcio
+E: hugo.locurcio@hugo.pro
+D: dist
+
+N: Jason Yundt
+E: swagfortress@gmail.com
+D: levels
+
+S: kitchen-ace
+E: 68k@quikphix.org
+D: levels, patches
+
+S: Korp
+E: korpkat@gmail.com
+D: buildcfg.txt, musics, patches, sprites
+
+S: m
+E: mchan223@shaw.ca
+D: buildcfg.txt, sounds, sprites
+
+S: mkrupczak3
+E: matthew@krupczak.org
+D: manual
+
+S: Mortrixs19
+D: levels
+
+N: Nicholas Zatkovich
+S: NickZ
+E: nzatkovich@gmail.com
+D: .github, levels
+
+S: ObsidainPlague
+D: musics
+
+N: Perry Fraser
+S: perry
+E: me@pprogs.blog
+D: levels
+
+S: shino1
+E: nobody.shinobi@gmail.com
+D: buildcfg.txt, sprites
+
+N: Steven Elliott
+E: selliott512@gmail.com
+D: buildcfg.txt, BUILD-SYSTEM.adoc, levels, Makefile, README.adoc, scripts, sprites
+
+N: Tyler True
+D: Makefile
+
 =======

--- a/CREDITS
+++ b/CREDITS
@@ -879,12 +879,8 @@ S: kitchen-ace
 E: 68k@quikphix.org
 D: levels, patches
 
-S: Korp
-E: korpkat@gmail.com
-D: buildcfg.txt, musics, patches, sprites
-
 S: m
-E: mchan223@shaw.ca
+E: verdantdregs@shaw.ca
 D: buildcfg.txt, sounds, sprites
 
 S: mkrupczak3

--- a/README.adoc
+++ b/README.adoc
@@ -237,3 +237,13 @@ version control systems, adopted by projects such as Linux and Git.
 For an explanation of this style, see
 https://chris.beams.io/posts/git-commit/[How to Write a Git Commit
 Message].
+
+If you create a git commit for someone else it is helpful to set the
+author of the commit so that they get credit. Ask them what name/alias
+and email they would like to use. For example:
+[source,bash]
+-----------------
+git commit --author "Bob Smith <bob@example.com>" ...
+-----------------
+If they prefer not to give an email then the email can be omitted, so
+just "Bob Smith" in the above example.


### PR DESCRIPTION
Also, update README.adoc to encourage people to set the author of commits correctly when creating commits on behalf of others.

---

I thought I'd limit the search to just since the last release.

For the work done (for `D`) I just used top level files or directories modified. For example, here's what Korp modified since v0.12.1:
```
a=Korp; git log --no-merges v0.12.1..origin/master --format=format: --name-only --author $a | sed 's|/.*$||g' | sort -u | grep -v '^$'  | tr \\012 , | sed 's|,$||g; s|,|, |g'; echo
buildcfg.txt, musics, patches, sprites
```

I attempted to merge what I found with any existing entries.

Fraggle, I updated your email address from `idgames@soulsphere.org` to `fraggle@soulsphere.org` based on your recent commits.