### PR TITLE
textures: add smaller MIDSPACE.

### DIFF
--- a/lumps/textures/textures.cfg
+++ b/lumps/textures/textures.cfg
@@ -1023,6 +1023,8 @@ MIDBRONZ        64      128
 *   RW10_4      0       0
 MIDSPACE        64      128
 *   RW47_1      0       0
+MIDSPCSM        64      72
+*   RW47_1      0       0
 MODWALL1        64      128
 *   RW31_1      0       0
 MODWALL2        64      128


### PR DESCRIPTION
A lot of IRL chainlink fences aren't nearly as tall as the full-height 128-unit texture we have now. An extra fence texture can be useful when creating more realistic environments.

(Disclosure of interest: yes the new back alley in Map16 is bugged in vanilla right now. I've got a fix lined up that sets that fence to extend the full 128 units off the ground but if this gets merged first I intend to go back and fix it the right way.)