### PR TITLE
Update GitHub Actions "make" script

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Get full repository history
@@ -42,7 +42,7 @@ jobs:
         if [[ ${VERSION:0:1} == "v" ]]; then
           export VERSION=${VERSION:1}
         fi
-        echo "::set-output name=VERSION::$VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Upload Freedoom
       uses: actions/upload-artifact@v1
       with:
@@ -53,4 +53,3 @@ jobs:
       with:
         path: "artifacts/freedm"
         name: freedm-${{steps.buildstep.outputs.VERSION}}
-


### PR DESCRIPTION
This script currently throws these warnings:

![image](https://user-images.githubusercontent.com/462484/229062360-4c547cd4-5255-48f0-878f-01a18edf2026.png)

Reading the relevant blog posts, I can see that the CI will just end up being completely broken by June, and this PR is meant to prevent that from happening.

It makes the following changes:
- Switch from `actions/checkout@v2` to `actions/checkout@v3`. There are no real changes in how the action itself is used (at least none relevant to our use case), so it's a simple version bump.
- Changes the `::set-output` command to use Environment Files instead. Other than how the command itself is written, there are no changes to its use, so it amounts to just a small change in syntax.