### PR TITLE
dehacked: correct Thing #109's height.

### DIFF
--- a/lumps/dehacked/dehacked.txt
+++ b/lumps/dehacked/dehacked.txt
@@ -38,6 +38,15 @@ Duration = 4
 Frame 48
 Duration = 3
 
+# Things 104 and 109 both hang from ceiling and use the same sprite,
+# but 109 (the non-blocking one) is height 52 instead, causing its
+# sprite to clip into the ceiling since the sprite offset is meant
+# for thing 104's correct height of 84.
+# This sets the non-blocker's height to match its counterpart.
+
+Thing 109
+Height = 5505024
+
 # This is a magic comment recognized by Chocolate Doom, so that the
 # BEX [STRINGS] section below will be parsed:
 #


### PR DESCRIPTION
Here's what it looks like *without* the fix:
![deadsargeoffset](https://user-images.githubusercontent.com/24984517/232259117-0d6e02fe-782f-4e9b-a744-2620c8684bdd.png)
The problem also exists in id, so we can trust that any mod that deals with this object will also be dealing with the height.
![DOOM00](https://user-images.githubusercontent.com/24984517/232259132-a4d76f64-64f6-4b32-8053-0ad85407af87.png)