### PR TITLE
scripts: Signed ints for grAb in fix-gfx-offsets

### DIFF
--- a/scripts/fix-gfx-offsets
+++ b/scripts/fix-gfx-offsets
@@ -20,7 +20,7 @@ class Graphic(object):
         reader = png.Reader(file=open(self.filepath, "rb"))
         for chunk in reader.chunks():
             if chunk[0] == "grAb":
-                self.xoffset, self.yoffset = struct.unpack(">II", chunk[1])
+                self.xoffset, self.yoffset = struct.unpack(">ii", chunk[1])
                 self.has_offset = True
 
 


### PR DESCRIPTION
The fix-gfx-offsets script incorrectly used unsigned integers (I) when interpreting grAb chunks, which resulted strange large values that are close to 2^32 in buildcfg.txt. The fix is to use signed integers (i).

---

This two character fix prevents strange and clearly wrong values in `buildcfg.txt`. For example, consider this hunk from the `buildcfg.txt` diff produces by running `make fix-gfx-offsets`:
```
@@ -2213,8 +2213,8 @@ PISFA0 -147 -66
 PISGA0 -138 -104
 PISGB0 -138 -83
 PISGC0 -139 -88
-PISGD0 -140 -87
-PISGE0 -141 -90
+PISGD0 4294967156 4294967209
+PISGE0 4294967155 4294967206
 PISTA0 10 14
 PLAYA1 18 54
 PLAYA2A8 11 54
```
Each of the four large values is 2^32 added to the corresponding negative value seen above it. For example:
```
4294967156 = 4294967296 -140
```
where 4294967296 = 2^32.