### PR TITLE
CREDITS: Update GojiBerry, remove merge remnants

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -951,7 +951,7 @@ D: levels
 
 S: GojiBerry
 E: gojidoesit@proton.me
-D: levels
+D: sound
 
 N: Jaden LeMieux
 S: iRedMC
@@ -964,5 +964,3 @@ S: Owly
 E: owlgal69@protonmail.com
 W: https://owly.fans
 D: Freedoom website
-
-=======


### PR DESCRIPTION
GojiBerry should be credited for "sound" not "levels". Also, the "=======" at the end is almost certainly left over from a previous git merge conflict - it has exactly the seven characters expected. I kept it until now thinking it had some meaning to something, but that's unlikely.