### PR TITLE
create_caption: Python PIL 10.0.0 support

### DIFF
--- a/graphics/text/create_caption
+++ b/graphics/text/create_caption
@@ -18,8 +18,21 @@ background_image.load()
 background_image = background_image.convert("RGBA")
 image = Image.new("RGBA", background_image.size, (0, 0, 0, 0))
 draw = ImageDraw.Draw(image)
-txt1_size = draw.textsize(txt1, font=font)
-txt2_size = draw.textsize(txt2, font=font)
+
+# Getting the text size is tricky since for newer PIL, such as 10.0.0, only
+# textbbox() is supported, but for older PIL, such 7.2.0, only textsize()
+# is supported. The solution is to default to the newer API, but fallback to
+# the older one when it is not available.
+try:
+    # This newer API returns a four item tuple. The "xy" kwarg is returned in
+    # the first two items, and last two items is the size needed, but with "xy"
+    # added, so passing "(0, 0)" returns the size needed.
+    txt1_size = draw.textbbox(xy=(0, 0), text=txt1, font=font)[2:]
+    txt2_size = draw.textbbox(xy=(0, 0), text=txt2, font=font)[2:]
+except:
+    # This older API simply returns the size needed.
+    txt1_size = draw.textsize(txt1, font=font)
+    txt2_size = draw.textsize(txt2, font=font)
 
 draw.text(
     (5, int(image.height - txt1_size[1] - 5)),


### PR DESCRIPTION
To support Python PIL 10.0.0 this change uses newer API textbbox() when available, and older API textsize() when not.

---

I've tested this using a static version in `Makefile` (the version otherwise causes the PNGs produces to be different):
```
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-VERSION=$(shell git describe --abbrev=8 --dirty 2>/dev/null || echo v0.12.1)
+VERSION=static-version
```
and found that it produces exactly the same `graphics/fd*title.png` PNGs for PIL 7.2.0 and 10.0.0 with this change, which again match the PNGs produces for 7.2.0 without this change.