### PR TITLE
dehacked: remove armour blinking.

### DIFF
--- a/lumps/dehacked/dehacked.txt
+++ b/lumps/dehacked/dehacked.txt
@@ -27,6 +27,14 @@ Sprite subnumber = 32773
 Frame 689
 Sprite subnumber = 32773
 
+# The armour fullbright blinking never made sense.
+
+Frame 803
+Sprite subnumber = 1
+
+Frame 805
+Sprite subnumber = 1
+
 # The super shotgun's first frame is 7 tics long before it
 # begins its reload sequence, but the muzzle flash animation
 # totals 9 tics, causing the flash to trail behind the gun.


### PR DESCRIPTION
The single most annoying creative constraint in creating an armour sprite is to explain why it's a blinking light. It never made sense in id and the explanation looks ridiculous in the new sprites in the recent devbuilds. (I say this as the person who added them - it's still in my view preferable to the alternative pure arbitrariness.)

If we get rid of the fullbright, we can design armour like any other mundane tech/ammo/weapon pickup.

This should be merged only after the current armour sprites have been replaced, as the current ones are clearly supposed to be fullbright in their B frames.