### PR TITLE
manual: optimize for PDF formatting.

### DIFF
--- a/manual/Makefile
+++ b/manual/Makefile
@@ -1,4 +1,4 @@
-ASCIIDOCTOR_FLAGS = -a toc -a pdf-page-size=A5
+ASCIIDOCTOR_FLAGS = -a pdf-page-size=A5
 all: freedoom-manual.pdf freedoom-manual-es.pdf
 
 freedoom-manual.pdf: manual.adoc

--- a/manual/manual-es.adoc
+++ b/manual/manual-es.adoc
@@ -1,17 +1,19 @@
 = Manual de Freedoom
 // SPDX-License-Identifier: BSD-3-Clause
+:toc:
+:toc-title:
+
+image::../graphics/titlepic/titlepic.png[Freedoom Title Image,align="center",width=380,pdfwidth=50vw]
 
 Bienvenido a Freedoom, un juego completo que es software
 https://www.gnu.org/philosophy/free-sw.html[libre]
 y de https://opensource.org/osd/[código abierto].
-Freedoom esta disponible bajo una licencia BSD modificada, lo que significa
+Freedoom esta disponible bajo una <<licence,licencia BSD modificada>>, lo que significa
 que cualquiera es libre de compartirlo, modificarlo y reutilizar partes de el.
 
-Para más detalles, ver la <<reusing,sección de reuso>>.
+Para más detalles, ver el sitio web en https://freedoom.github.io/.
 
 Traducción: NecSau, DoomguyAlighieri, Alaux
-
-image::../graphics/titlepic/titlepic.png[Freedoom Title Image,align="center",width=380,pdfwidth=50vw]
 
 == Instalar Freedoom
 
@@ -100,13 +102,15 @@ el numero de monstruos con los que te encontraras.
 
 image::images/menu-skill.png[Skill Selection Menu,align="center",width=473,pdfwidth=50vw]
 
-[cols="1,3,8",width="90%",align="center",valign="middle"]
+[cols="1,5,13",width="90%",align="center",valign="middle"]
 |==========================
-| 1 | **Please Don’t Kill Me!** | El nivel de dificultad más sencillo. Este es
+| 1 | **Please Don’t +
+Kill Me!** | El nivel de dificultad más sencillo. Este es
 esencialmente igual a _Will This Hurt?_, excepto que el daño enemigo se reduce
 a la mitad.
 | 2 | **Will This Hurt?** | Nivel de dificultad fácil.
-| 3 | **Bring on the Pain.** | El nivel de dificultad default.
+| 3 | **Bring On +
+The Pain.** | El nivel de dificultad default.
 | 4 | **Extreme Carnage.** | Nivel de dificultad difícil.
 | 5 | **MAYHEM!** | **No Recomendado**. Esto es equivalente a _Extreme Carnage_
 con la excepción de que los ataques de los monstruos son el doble de rápidos, y
@@ -159,7 +163,7 @@ lo dejaste la próxima vez que juegues.
 Los siguientes son algunos útiles atajos del teclado que pueden ahorrarte
 tiempo para acceder a funciones comunes del menú.
 
-[cols="1,3,7",width="90%",align="center",valign="middle"]
+[cols="2,6,16",width="90%",align="center",valign="middle"]
 |==========================
 | **Esc** | <<menus,Menu>> | Muestra el menú principal.
 | **F1** | Help | Muestra la pantalla de ayuda que muestra información de los
@@ -194,29 +198,26 @@ interruptor para abrir un paso. Esto le da un elemento de
 rompecabezas al juego que se añade a la acción.
 
 Estos son los controles principales del juego para interactuar con el entorno:
-[options="header",cols="3,1,2,1",width="70%",align="center",halign="center"]
+[options="header",cols="1,1,1,1",width="100%",align="center",halign="center"]
 |==========================
-| Function | Primera tecla default^1^ | Segunda tecla default | Comúnmente configurado para^2^
-| Avanzar/Retroceder | Up/Down | Movimiento del mouse (o Mouse2 para avanzar) | W/S
+| Function | Primera control default | Segunda control default | Comúnmente configurado para
+| Avanzar/Retroceder | Up/Down | Movimiento del mouse (o Mouse2 para avanzar) | W/S^1^
 | Mover a la izquierda/derecha | ,/. | Alt (o Mouse3) + izquierda/derecha | A/D
-| Girar a la izquierda/derecha^3^ | Izquierda/Derecha | Movimiento del mouse | Movimiento del mouse
+| Girar a la izquierda/derecha^2^ | Izquierda/Derecha | Movimiento del mouse | Movimiento del mouse
 | Disparo | Ctrl | Mouse1 | Mouse1
 | Usar | Espaciadora | Doble clic Mouse2 o Mouse3 | E
-| Correr^4^ | Mayúsculas | - | Mayúsculas
+| Correr^3^ | Mayúsculas | - | Mayúsculas
 |==========================
-^1^Tu source port debería permitirte usar cualquier botón de tu controlador o mouse;
-por brevedad, este manual usa "tecla" para incluir otros controles según
-lo requieran las circunstancias.
 
-^2^En un teclado QWERTY las teclas W, S, A y D forma un segundo juego
+^1^En un teclado QWERTY las teclas W, S, A y D forma un segundo juego
 de teclas de dirección para la mano izquierda.
 
-^3^Si tienes un monstruo, un barril o un oponente PvP cruzando el medio
+^2^Si tienes un monstruo, un barril o un oponente PvP cruzando el medio
 de tu pantalla cuando tu arma se dispara, el juego ajustará tu puntería
 vertical por ti. Algunos source ports te permitirán desactivar este
 comportamiento y ajustar la puntería vertical manualmente.
 
-^4^La mayoría de los source ports tienen una opción de "Correr siempre"
+^3^La mayoría de los source ports tienen una opción de "Correr siempre"
 ("Always Run"), en la que si mantienes pulsada esta tecla, irás más despacio.
 El personaje del jugador no se cansa, así que la velocidad lenta
 sólo es necesaria para aumentar la precisión.
@@ -350,52 +351,53 @@ Presiona la tecla numerada en el teclado para cambiar al arma correspondiente
 (si lo tiene). Con excepción de las armas cuerpo a cuerpo, cada
 arma consume cierto tipo de munición, que puede encontrarse en algún lugar del nivel.
 
-[options="header",cols="3,1,5",valign="middle",width="100%"]
+[options="header",cols="3,1,9",valign="middle",width="100%"]
 |==========================
 | Arma | Tecla | Descripción
 | **Puño** | 1 | Si no tienes munición, siempre puedes recurrir a golpear a los
-monstruos con tus manos desnudas. Munición: Ninguna
+monstruos con tus manos desnudas. _Munición:_ Ninguna
 | **Sierra de hender** +
 image:../sprites/csawa0.png[Sierra de hender] |
 1 | Diseñada para cortar a través del madera, pero la
 sierra de hender funciona igual de bien como arma cuerpo a cuerpo para cortar
-a través de la carne. Munición: Ninguna
+a través de la carne. +
+_Munición:_ Ninguna
 | **Pistola** +
 image:../sprites/pista0.png[Pistola] |
 2 | Tu arma inicial. Su objetivo principal es permitirte abrirte camino hacia
 una mejor arma, y presionar interruptores disparables sin desperdiciar
-una segunda bala. Munición: Balas
+una segunda bala. _Munición:_ Balas
 | **Escopeta de bombeo** +
 image:../sprites/shota0.png[Escopeta de bombeo] |
 3 | Dispara siete perdigones en forma de abanico, lo que le permite golpear
-múltiples objetivos o uno grande. Munición: Perdigones
+múltiples objetivos o uno grande. _Munición:_ Perdigones
 | **Escopeta de doble cañón** +
 image:../sprites/sgn2a0.png[Escopeta de doble cañón] |
 3 | Mayor tolerancia a cargas potentes significa mejor fragmentación
 del proyectil, para casi un 50% más de impactos por cartucho a través de
 una dispersión más amplia. Es buena a corto alcance contra grupos de
-enemigos. Munición: Perdigones
+enemigos. _Munición:_ Perdigones
 | **Minigun** +
 image:../sprites/mguna0.png[Minigun] |
 4 | Un uso mucho mejor para los balas que la pistola.
-Hasta cuarenta segundos de traer el dolor para mantenerte a salvo.
-Munición: Balas
+Hasta cuarenta segundos de traer el dolor para mantenerte a salvo. +
+_Munición:_ Balas
 | **Lanzamisiles** +
 image:../sprites/launa0.png[Lanzamisiles] |
 5 | Dispara misiles que tratan mucho daño en el impacto, y explotan para matar
 pequeños monstruos cercanos. ¡Ten cuidado de no ser atrapado en la explosión!
-Munición: Misiles
+_Munición:_ Misiles
 | **Arma de energía polarica** +
 image:../sprites/plasa0.png[Arma de energía polarica] |
 6 | Produce un continuo flujo de proyectiles de
-energía polarica. Los cuales son efectivos contra monstruos más fuertes.
-Munición: Energía
+energía polarica. Los cuales son efectivos contra monstruos más fuertes. +
+_Munición:_ Energía
 | **SKAG 1337** +
 image:../sprites/bfuga0.png[SKAG 1337] |
 7 | Un arma experimental que lanza una bola orbe de energía polarica que
 hace una gran cantidad de daño, y suelta una ráfaga secundaria de energía
 en la misma dirección. Lenta para disparar, vale la pena esperar.
-Munición: Energía
+_Munición:_ Energía
 |==========================
 
 [[ammo]]
@@ -534,14 +536,16 @@ image:../sprites/pinva0.png[Artefacto de vanguardia] |
 Te hace inmune a todo el daño por tiempo limitado.
 |==========================
 
+<<<
+
 [[enemies]]
 === Enemigos
 
 Los niveles están llenos de monstruos que no tienen otro objetivo más que
-impedir que completes tu misión. Aquí hay una selección de algunos de estos
+impedir que completes tu misión. Aquí hay una selección de
 monstruos con los que puedes encontrarte.
 
-[frame="none",cols="2,1",valign="middle",grid="none",align="center",width="100%"]
+[frame="none",cols="5,2",valign="middle",grid="none",align="center",width="100%"]
 |==========================
 | **Zombi** +
 Estas obradores de iniquidad con muerte cerebral están armadas con una pistola y tienen
@@ -596,12 +600,12 @@ Si no te está prendiendo fuego, está deshaciendo todo tu arduo trabajo al trae
 a sus amigos de entre los muertos. |
 image:images/monster-necromancer.png[Necromancer,100,100,width=100%]
 | **Babosa de batalla** +
-Estos monstruos de carne diseñados genéticamente han sido equipados con lanzallamas
-de larga distancia, convirtiéndolos en tanques vivientes y deslizantes. |
+Estos tanques vivientes y deslizantes diseñados genéticamente han sido
+equipados con lanzallamas de larga distancia. |
 image:images/monster-combat-slug.png[Babosa de batalla,100,100,width=100%]
 | **Tecnaraña** +
 Estas criaturas cibernéticas han sido equipadas con ametralladoras de energía
-polarica, lo que las convierte en un desafío mortal. |
+polarica. |
 image:images/monster-technospider.png[Tecnaraña,100,100,width=100%]
 | **Tecnaraña grande** +
 Este tanque con patas está equipado con una ametralladora de fuego rápido y
@@ -659,7 +663,7 @@ independientemente de tu posición actual.
 Por si los monstruos no fueran suficientes, el ambiente mismo posee peligros
 que pueden lastimarte, ¡o incluso matarte!
 
-[frame="none",cols="2,5,3",valign="middle",grid="none",width="100%"]
+[frame="none",cols="3,7,3",valign="middle",grid="none",width="100%"]
 |==========================
 | **Barriles** |
 Estos barriles explosivos ensucian muchos de los niveles. Varios disparos con
@@ -690,8 +694,8 @@ tu avatar de jugador morirá. Puedes tomar esto como una señal para tomar
 un descanso del juego, o recargar tu último juego guardado, o presionar
 Usar para reiniciar el nivel con plena salud pero sin equipo excepto tu
 pistola y 50 balas. (Algunos source ports no hacen esto último, sino
-que guardan el juego al comienzo de cada nivel y al presionar Usar se
-carga ese juego).
+que guardan el juego al comienzo de cada nivel, en cuyo caso al presionar
+_Usar_ se carga ese juego).
 
 No hay límite de vidas.
 
@@ -739,7 +743,7 @@ considerar algunas de estas sugerencias:
   oponentes. Un solo disparo de escopeta en el momento oportuno dirigido a un
   barril puede derribar a varios enemigos a la vez. La explosión de un barril
   puede desencadenar otro, por lo que a veces puedes desencadenar una reacción
-  en cadena que derriba a toda una multitud, ¡pero ten cuidado de que no te
+  en cadena que derriba a toda una multitud. ¡Ten cuidado de que no te
   incluya a ti!
 
 * Si un monstruo es herido por otro monstruo, tomará represalias contra el que
@@ -824,12 +828,11 @@ siguientes son algunas sugerencias sobre dónde buscar el mejor contenido:
 
 == Trucos
 
-Si encuentra el juego demasiado difícil, siempre puede intentar jugar en
-<<skill,un nivel de dificultad más fácil>>. Sin embargo, si eso no es
-suficiente, o si solo quieres experimentar con la mecánica del juego,
-hay una serie de trucos a los que puedes recurrir:
+Si no puedes pasar de cierto punto, o si quieres experimentar con
+la mecánica del juego, hay algo chetos a los que puedes recurrir.
+(Introdúcelos durante el juego, no abras la consola.)
 
-[cols="2,4",width="90%",align="center",valign="middle"]
+[cols="2,6",width="100%",align="center",valign="middle"]
 |==========================
 | **IDDQD** | Modo Dios. Te hace invulnerable a todo el daño.
 | **IDFA** | Te da todas las armas y munición.
@@ -903,18 +906,23 @@ libertad de expresión) para los usuarios finales, siempre que la licencia de
 software original esté incluida y/o sea visible para los usuarios del software
 modificado o versiones redistribuidas.
 
-Si te gustaría contribuir al proyecto Freedoom, por favor revisa la
-https://github.com/freedoom/freedoom[página del proyecto],
-https://www.doomworld.com/forum/17-freedoom/[foros de discusión], y el
-https://discord.gg/9DA3fut[chat de discord].
+Si te gustaría contribuir al proyecto Freedoom, por favor revisa:
 
-https://help.github.com/es/github[Cómo usar el control de versiones de Git para
-contribuciones].
+* la página del proyecto: +
+https://github.com/freedoom/freedoom
 
-https://guides.github.com/activities/forking/[Cómo bifurcar un proyecto y crear
-una solicitud de extracción con Git (Revisar)].
+* los foros de discusión: +
+https://www.doomworld.com/forum/17-freedoom/
 
-<<<
+* el chat de Discord: https://discord.gg/9DA3fut
+
+Para más información sobre cómo enviar una adición, consulte las páginas sobre cómo utilizar GitHub:
+
+* Cómo usar el control de versiones de Git para contribuciones: +
+https://help.github.com/es/github
+
+* Cómo bifurcar un proyecto y crear una solicitud de extracción con Git (Revisar): +
+https://guides.github.com/activities/forking/
 
 [[reusing]]
 == Reusar porciones Freedoom
@@ -923,6 +931,39 @@ Dado que https://freedoom.github.io/about.html[Freedoom es libre], algunos
 otros proyectos han utilizado los materiales de Freedoom. Creemos que este es
 un gran uso del proyecto y debe fomentarse. Si tu usas partes de Freedoom en tu
 proyecto, puedes informarnos presentando una solicitud a
-https://github.com/freedoom/freedoom.github.io[la página web del proyecto
-Freedoom].
+la página web del proyecto Freedoom en https://github.com/freedoom/freedoom.github.io.
 
+
+[[licence]]
+=== Licencia BSD modificada (inglés)
+
+Copyright © 2001-2023
+Contributors to the Freedoom project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the Freedoom project nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS
+IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For a list of contributors to the Freedoom project, see the file
+CREDITS.

--- a/manual/manual-es.adoc
+++ b/manual/manual-es.adoc
@@ -63,7 +63,7 @@ presionar la tecla _Esc_ en tú teclado.
 
 image::images/menu-mainmenu.png[Menú principal de Freedoom,align="center",width=380,pdfwidth=50vw]
 
-[cols="1,4",width="90%",align="center",valign="middle"]
+[cols="2,5",width="100%",align="center",valign="middle"]
 |==========================
 | <<newgame,**New game**>> | Comienza un Nuevo Juego, abandonando el juego en
 curso (Si ya estas jugando).
@@ -72,9 +72,9 @@ opciones disponibles dependen del source port que eses usando.
 | <<savegame,**Load Game**>> | Carga un juego guardado.
 | <<savegame,**Save Game**>> | Guarda el juego en curso, para que puedas
 continuar jugando después.
-| **Read This!** | Despliega una pantalla de ayuda que muestra una descripción
-de los objetos que puedes encontrar en el juego.
-| **Quit Game** | Termina el juego y regresa al Sistema operativo.
+| **Read This!** | Despliega una pantalla de ayuda con los objetos
+que puedes encontrar en el juego.
+| **Quit Game** | Salir al Sistema operativo.
 |==========================
 
 [[newgame]]

--- a/manual/manual-es.adoc
+++ b/manual/manual-es.adoc
@@ -201,9 +201,9 @@ Estos son los controles principales del juego para interactuar con el entorno:
 [options="header",cols="1,1,1,1",width="100%",align="center",halign="center"]
 |==========================
 | Function | Primera control default | Segunda control default | Comúnmente configurado para
-| Avanzar/Retroceder | Up/Down | Movimiento del mouse (o Mouse2 para avanzar) | W/S^1^
-| Mover a la izquierda/derecha | ,/. | Alt (o Mouse3) + izquierda/derecha | A/D
-| Girar a la izquierda/derecha^2^ | Izquierda/Derecha | Movimiento del mouse | Movimiento del mouse
+| Avanzar / Retroceder | Up/Down | Movimiento del mouse (o Mouse2 para avanzar) | W/S^1^
+| Mover a la izquierda / derecha | ,/. | Alt (o Mouse3) + izquierda / derecha | A/D
+| Girar a la izquierda / derecha^2^ | Izquierda / Derecha | Movimiento del mouse | Movimiento del mouse
 | Disparo | Ctrl | Mouse1 | Mouse1
 | Usar | Espaciadora | Doble clic Mouse2 o Mouse3 | E
 | Correr^3^ | Mayúsculas | - | Mayúsculas

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -307,7 +307,7 @@ weapon.
 | **Armor** | The more armor you have, the less your health will suffer if
 you’re injured. See the <<armor,armor section>> for more information.
 | **Ammo counts** | How much you’re carrying of each of the <<ammo,four types of
-ammunition>>, along with the maximum of each you can carry.
+ammunition>>, and the maximum of each you can carry.
 |==========================
 
 <<<
@@ -438,7 +438,7 @@ image:../sprites/arm1a0.png[Force Field Armor Vest] |
 image:../sprites/arm2a0.png[Attuned Force Field Armor Vest]
 |==========================
 
-Normal armor absorbs 1/3 of damage you receive. Absorption is rounded down:
+Normal armor absorbs one third of damage you receive, rounded down.
 if you have 100 health and 100 armor and are hit for 50 damage, you'll lose
 34 health and 16 armor.
 
@@ -483,28 +483,28 @@ image:images/key-icons.png[Key icons,align="center"]
 [[specialitems]]
 === Special Items
 
-You may also encounter any one of these special items while exploring:
+You may also encounter any one of these while exploring:
 
-[cols="1,2",width="90%",align="center",valign="middle"]
+[cols="1,3",width="90%",align="center",valign="middle"]
 |==========================
 | **Low-Light Goggles** +
 image:../sprites/pvisa0.png[Low-Light Goggles] |
 Let you see in the dark. +
-Effect lasts 2 minutes.
+Lasts 2 minutes.
 | **Area Survey Map** +
 image:../sprites/pmapa0.png[Area Survey Map] |
 Reveals unexplored areas of the map, including some secret areas that
 may not be immediately visible. +
-Effective for the entire level and that level only.
+Lasts the entire level but effective only for the current level.
 | **Rescue Operations Suit** +
 image:../sprites/suita0.png[Rescue Operations Suit] |
 Protects you from heat, toxins and radiation from damaging floors. +
 Lasts 1 minute.
 | **Strength Symbiote** +
 image:../sprites/pstra0.png[Strength Symbiote] |
-Increases your health back to 100%, and enhances your fists to 10x their
+Increases your health back to 100%, and enhances your fists to do ten times their
 normal damage. +
-Health is permanent; damage increase lasts only for that level. +
+Health lasts until removed by damage; enhanced fists last only for that level. +
 | **Invisibility Cloak** +
 image:../sprites/pinsa0.png[Invisibility Cloak] |
 Makes you almost invisible. Monsters still detect
@@ -513,7 +513,7 @@ Lasts 1 minute.
 | **Negentropic Surge** +
 image:../sprites/megaa0.png[Negentropic Surge] |
 Maxes you out to 200% health+armor. +
-Permanent.
+Lasts until removed by damage.
 | **Vanguard Device** +
 image:../sprites/pinva0.png[Vanguard Device] |
 Makes you immune to all damage, allowing you to get

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -1,15 +1,17 @@
 = Freedoom Manual
 // SPDX-License-Identifier: BSD-3-Clause
+:toc:
+:toc-title:
+
+image::../graphics/titlepic/titlepic.png[Freedoom Title Image,align="center",width=380,pdfwidth=50vw]
 
 Welcome to Freedoom, a complete game that is
 https://www.gnu.org/philosophy/free-sw.html[free]
 and https://opensource.org/osd/[open source software].
-Freedoom is made available under the modified BSD license, meaning that
+Freedoom is made available under the <<licence,modified BSD license>>, meaning that
 anyone is free to share it, modify it and reuse parts of it.
 
-For more details, see the <<reusing,reusing section>>.
-
-image::../graphics/titlepic/titlepic.png[Freedoom Title Image,align="center",width=380,pdfwidth=50vw]
+For more details, see the website at https://freedoom.github.io/.
 
 == Installing Freedoom
 
@@ -34,14 +36,14 @@ instructions for that source port. Generally though, you can try one of the
 following:
 
 * Place the Freedoom `.wad` files into the same folder as the source port
-  before launching it. They may be automatically detected.
+  before launching. The source port may be able to automatically detect them.
 * If launching from the command line, try
   eg. `my-favorite-port -iwad freedoom1.wad`.
 
 Freedoom is split into _Freedoom: Phase 1_ (`freedoom1.wad`) and
 _Freedoom: Phase 2_ (`freedoom2.wad`). _Phase 1_ is split into four separate
 episodes of eight levels each, while _Phase 2_ is a single, 30 level campaign.
-This gives 62 levels to play through, and there are also secret levels -- if
+This gives 62 levels to play through, plus the secret levels -- if
 you can discover how to reach them.
 
 FreeDM (`freedm.wad`) is a monster-free set of levels, made specifically
@@ -58,7 +60,7 @@ _Esc_ key on your keyboard.
 
 image::images/menu-mainmenu.png[Freedoom Main Menu,align="center",width=380,pdfwidth=50vw]
 
-[cols="2,4",width="100%",align="center",valign="middle"]
+[cols="2,5",width="100%",align="center",valign="middle"]
 |==========================
 | <<newgame,**New game**>> | Start a new game, abandoning the current game (if you’re
 already playing).
@@ -67,9 +69,9 @@ and the available options depend upon the source port you’re using.
 | <<savegame,**Load Game**>> | Load a saved game.
 | <<savegame,**Save Game**>> | Save your current game, so that you can continue playing
 later.
-| **Read This!** | Brings up a help screen showing a description of the
+| **Read This!** | Brings up a help screen showing the
 items you’ll encounter in the game.
-| **Quit Game** | Finish playing and return to the operating system.
+| **Quit Game** | Exit to the operating system.
 |==========================
 
 [[newgame]]
@@ -97,12 +99,14 @@ monsters you’ll encounter.
 
 image::images/menu-skill.png[Skill Selection Menu,align="center",width=473,pdfwidth=50vw]
 
-[cols="1,3,8",width="90%",align="center",valign="middle"]
+[cols="1,5,13",width="90%",align="center",valign="middle"]
 |==========================
-| 1 | **Please Don’t Kill Me!** | The easiest skill level. This is
+| 1 | **Please Don’t +
+Kill Me!** | The easiest skill level. This is
 effectively the same as _Will This Hurt?_, except that damage is halved.
 | 2 | **Will This Hurt?** | Easy skill level.
-| 3 | **Bring on the Pain.** | The default skill level.
+| 3 | **Bring On +
+The Pain.** | The default skill level.
 | 4 | **Extreme Carnage.** | Hard skill level.
 | 5 | **MAYHEM!** | **Not Recommended**. This is equivalent to
 _Extreme Carnage_ except that monster attacks are up to twice as fast,
@@ -135,39 +139,35 @@ without navigating the menu.
 
 You can restore your quicksave slot with the menu or by pressing _F9_.
 
-[**Warning:** the original Doom program has a bug that makes it crash
-when you save a game while too much is going on in the level. Chocolate
-Doom intentionally emulates this bug. You may want to go into
-chocolate-setup and disable "Vanilla savegame limit" before playing.]
+[**Warning:** Chocolate Doom emulates an original _Doom_ bug that makes it crash
+when you save a game while too much is going on in the level. This can be disabled
+in `chocolate-setup` under "Vanilla savegame limit".]
 
 === Quitting the game
 
 When you’re finished playing Freedoom, press _Esc_ to bring up the main
-menu and select _Quit Game_ to exit. You may want to select _Save Game_
-first to save your progress so that you can return to where you left off
-next time you play.
+menu and select _Quit Game_ to exit. (You may want to <<savegame, save
+your game>> first.)
 
 === Keyboard shortcuts
 
-The following are some useful keyboard shortcuts that can save time
-accessing common menu functions.
+The function keys instantly open some common menu items:
 
-[cols="1,3,7",width="90%",align="center",valign="middle"]
+[cols="2,6,16",width="90%",align="center",valign="middle"]
 |==========================
 | **Esc** | <<menus,Menu>> | Bring up the main menu.
 | **F1** | Help | Bring up the help screen that shows information about the
 in-game items.
 | **F2** | <<savegame,Save>> | Bring up the _Save Game_ menu.
 | **F3** | <<savegame,Load>> | Bring up the _Load Game_ menu.
-| **F4** | Volume | Bring up a menu to control volume levels.
-| **F6** | <<savegame,Quicksave>> | Save the game to your _quicksave_ slot,
-which saves time if you’re repeatedly saving your progress while you play.
+| **F4** | Volume | Bring up the sound and music volume sliders.
+| **F6** | <<savegame,Quicksave>> | Save the game to your quicksave slot.
 | **F7** | End Game | End the current game and return to the title screen.
-| **F8** | Messages | Toggles between showing or hiding the on-screen
-messages shown when you collect an item.
-| **F9** | <<savegame,Quickload>> | Load the game from your _quicksave_ slot.
+| **F8** | Messages | Toggles showing on-screen messages for pickups,
+keys, cheats, etc..
+| **F9** | <<savegame,Quickload>> | Load the game in your quicksave slot.
 | **F10** | Quit Game | Quit the game and return to the operating system.
-| **F11** | Brightness | Cycle through the in-game brightness levels.
+| **F11** | Gamma | Cycle through the in-game display brightness levels.
 |==========================
 
 <<<
@@ -180,42 +180,40 @@ Freedoom is a real-time first-person shooter (FPS). You’ll be exploring a
 series of levels, in each one trying to find the way to the exit. An
 assortment of monsters will try to stop you, and you’ll need to use weapons
 to defend yourself. Portions of the levels may be inaccessible until you
-find a particular key, or find a switch to open a passage. This means that
-gameplay will involve hidden-object exploration puzzles as well as real-time
-action puzzles about placing and timing the shots of your weapons.
+find a particular key, or find a switch to open a passage. Gameplay will
+involve hidden-object exploration puzzles as well as real-time action
+puzzles about placing and timing the shots of your weapons.
 
-These are the core in-game controls for interacting with the environment:
-[options="header",cols="3,1,2,1",width="70%",align="center",halign="center"]
+A table of the core in-game controls follows. **_Doom_'s defaults are widely
+considered suboptimal;** check your source port for how to reconfigure them.
+Common alternatives are provided but no single "best" solution works for
+everyone -- you need to experiment. At minimum you must be comfortable
+moving in any one of the four directions while turning and shooting.
+
+[options="header",cols="1,1,1,1",width="100%",align="center",halign="center"]
 |==========================
-| Function | Default key^1^ 1 | Default key 2 | Commonly set to^2^
-| Move forward/backward | Up/Down | Mouse movement (or Mouse2 for forward) | W/S
+| Function | Default control 1 | Default control 2 | Common alternative
+| Move forward / backward | Up/Down | Move mouse (or Mouse2 for forward) | W/S^1^
 | Move ("strafe") left/right | ,/. | Alt (or Mouse3) + Left/Right | A/D
-| Turn left/right^3^ | Left/Right | Mouse movement | Mouse movement
+| Turn left/right^2^ | Left/Right | Move mouse | Move mouse
 | Fire | Ctrl | Mouse1 | Mouse1
 | Use | Space | Double-click Mouse2 or Mouse3 | E
-| Run^4^ | Shift | - | Shift
+| Run^3^ | Shift | _<none>_ | Shift
 |==========================
-^1^Your source port should allow you to use any button on your controller
-or mouse; for brevity, "key" is used in this manual to include
-other controls as circumstances require.
 
-^2^On a QWERTY keyboard the W, S, A and D keys
+^1^On a QWERTY keyboard the W, S, A and D keys
 form a second set of arrow keys for the left hand.
 
-^3^If you have a monster, a barrel or a PvP opponent crossing the middle
+^2^If you have a monster, a barrel or a PvP opponent crossing the middle
 of your screen when your weapon discharges, the game will adjust your
 vertical aim for you. Some source ports will let you disable this
 behaviour and aim manually instead.
 
-^4^Most source ports have an "Always Run" option where holding this key
-makes you go slower instead. The player character does not get tired so
-the slow speed is only necessary for increased precision.
+^3^Most source ports have an "Always Run" option where holding this key
+makes you go slower instead. Since the player character does not get tired,
+going slow only helps for increased precision.
 
-**Doom's defaults are widely considered suboptimal;** check your source port
-for how to reconfigure them. The most common options are provided but there is
-no one "best" solution that works for everyone -- you may need to experiment.
-At minimum you must be comfortable moving in any one of the four directions
-while simultaneously turning and shooting.
+<<<
 
 === A Tutorial
 
@@ -229,61 +227,66 @@ Skip anything that bores or confuses you, and redo anything you find
 challenging as long as you like, before moving on to the next thing or
 redoing a previous thing.
 
-* Try moving forward, backward, left, and right.
+1. Try moving forward, backward, left, and right.
   Trace a square. Try both directions. Try doing a figure eight.
   (Don't leave the cage yet -- there are monsters outside.)
 
-* Turn around in a circle to examine your surroundings. Go at your own pace,
+1. Turn around in a circle to examine your surroundings. Go at your own pace,
   stopping or reversing to look at anything whenever you want.
   Do a second circle, moving a little bit as you go, and watch how that
   changes the perspective and how sideways movement can help you see
   how long a wall or how far away an object is.
 
-* Move back to the middle of the cage. Turn to point your handgun
+1. Move back to the middle of the cage. Turn to point your handgun
   directly at one of the doorframe columns.
 
-* Move -- without turning -- so that your handgun is pointed at the other column.
+1. Move -- without turning -- so that your handgun is pointed at the other column.
  (Bonus points if you can come to a natural stop on target.)
 
-* Move a bit left or right, then turn to point at the column again.
+1. Move a bit left or right, then turn to point at the column again.
   Do it again, but start turning before your momentum wears off.
   Do this again a few times, cycling through all four directions and turning
   sooner and sooner until you are pointing and the moving seamlessly.
-  (Move backwards or forwards to reset if you get too close or are
-  running into walls.)
+  (Move backwards or forwards to reset if you start running into walls.)
 
-* Try doing a square (or figure eight, etc.) while pointing at the column
+1. Try doing a square (or figure eight, etc.) while pointing at the column
   the entire time. Prioritize smoothness over precision -- it's better to
   be close most of the time than perfect some of the time.
 
-* Move to one of the corners with the beds on them so that the column is
+1. Move to one of the corners with the beds on them so that the column is
   no longer in your line of sight. Move in and out of sight with
   the column playing "Peek-A-Boo" with it. Mess with distance and timing.
   Try to stay pointed at the column even when you can't see it.
 
-* Play around with the above for a bit. Try pressing the Fire key to shoot at
+1. Play around with the above for a bit. Try pressing the Fire key to shoot at
   the column, both standing still and moving, and note where and when
   the bullet puffs appear. (Stop shooting before your ammo count goes below
   30 or so -- you will need those for later!)
 
-* Tap the 1 key on the keyboard to switch to your fist, and try to punch the
+1. Tap the 1 key on the keyboard to switch to your fist, and try to punch the
   column and see how far away you can do it. Tap the 2 key to switch back
   to the handgun.
 
-* See if you can still do everything while holding down the Run key.
+1. Try to do everything while holding down the Run key.
 
-* Move down into the trench and kill a <<enemies,zombie>>. Try not to get hit.
+1. Enter the trench and kill a <<enemies,zombie>>. Try not to get hit.
 
-* Once you're safe, look near the zombie's body to see if it may have left
+1. Once you're safe, look near the zombie's body to see if it may have left
   a <<ammo,clip>>. If it has, move over it to pick it up.
 
-* Go back the way you came. Go up to the lift like you're going to punch it,
+1. Go back the way you came. Go up to the lift like you're going to punch it,
   then hit Use to call it down. Get on it and it will take you back up.
   Pick up the items in the upper area to restore or boost your health.
 
-* Explore the rest of the area. You will find two pathways, one of each type:
-  the bottom one will lead you to the main path, while the other one will lead you to the alternate path. Once you've decided which way to go,
-  open the door -- and get ready to start playing Gun Peek-A-Boo again.
+1. Explore the rest of the area. You will find two doors, which can be
+  opened with the Use key just like the lift. The lower door will take you
+  closer to the exit, while the higher one leads to a more
+  difficult but more rewarding detour.
+
+1. Once you've decided which way to go, open the door -- and get ready
+  to start playing Gun Peek-A-Boo again...
+
+<<<
 
 === The Status Bar
 
@@ -306,6 +309,8 @@ you’re injured. See the <<armor,armor section>> for more information.
 | **Ammo counts** | How much you’re carrying of each of the <<ammo,four types of
 ammunition>>, along with the maximum of each you can carry.
 |==========================
+
+<<<
 
 [[items]]
 === Items
@@ -330,50 +335,50 @@ Pressing the number key on the keyboard switches to the given weapon
 (if you have it). Apart from the melee weapons, each weapon consumes a
 certain type of ammo, which may be found somewhere in the level.
 
-[options="header",cols="3,1,5",valign="middle",width="100%"]
+[options="header",cols="3,1,9",valign="middle",width="100%"]
 |==========================
 | Weapon | Key | Description
 | **Fist** | 1 | If you have no ammunition, you can always fall back on punching the
-monsters with your bare hands. Ammo: None
+monsters with your bare hands. _Ammo:_ None
 | **Ripsaw** +
 image:../sprites/csawa0.png[Ripsaw] |
 1 | Designed for cutting through wood, the ripsaw
-also works well as a melee weapon for cutting through flesh. Ammo: None
+also works well as a melee weapon for cutting through flesh. _Ammo:_ None
 | **Handgun** +
 image:../sprites/pista0.png[Handgun] |
 2 | Your starter weapon. Its main purpose is to let you fight your way to
 a better weapon, and to hit shootable switches without wasting a second bullet.
-Ammo: Bullets
+_Ammo:_ Bullets
 | **Pump-action Shotgun** +
 image:../sprites/shota0.png[Pump-action Shotgun] |
 3 | Shoots seven pellets in a fan pattern, letting you hit multiple
-targets or one big one. Ammo: Shells
+targets or one big one. _Ammo:_ Shells
 | **Double-barrelled Shotgun** +
 image:../sprites/sgn2a0.png[Double-barrelled Shotgun] |
 3 | Stronger tolerance for powerful loads means better
 projectile fragmentation for almost 50% more hits per shell
 across a wider spread. Good for short range against groups of
-enemies. Ammo: Shells
+enemies. _Ammo:_ Shells
 | **Minigun** +
 image:../sprites/mguna0.png[Minigun] |
 4 | A much better use for your bullets than the handgun.
 Up to forty seconds of bringing the pain to keep you safe.
-Ammo: Bullets
+_Ammo:_ Bullets
 | **Missile Launcher** +
 image:../sprites/launa0.png[Missile Launcher] |
 5 | Fires missiles that deal a lot of damage on impact, then explode to take
 out any smaller monsters nearby. Be careful not to get caught in the blast!
-Ammo: Missiles
+_Ammo:_ Missiles
 | **Polaric Energy Weapon** +
 image:../sprites/plasa0.png[Polaric Energy Weapon] |
 6 | Produces a continuous stream of polaric energy
 projectiles which are very effective against stronger monsters.
-Ammo: Energy
+_Ammo:_ Energy
 | **SKAG 1337** +
 image:../sprites/bfuga0.png[SKAG 1337] |
 7 | Experimental weapon that launches a single massive polaric energy ball,
 then releases a secondary energy blast in the same direction!
-Slow to shoot, but worth the wait. Ammo: Energy
+Slow to shoot, but worth the wait. _Ammo:_ Energy
 |==========================
 
 [[ammo]]
@@ -433,7 +438,7 @@ image:../sprites/arm1a0.png[Force Field Armor Vest] |
 image:../sprites/arm2a0.png[Attuned Force Field Armor Vest]
 |==========================
 
-Normal armor absorbs one third of damage you receive. Absorption is rounded down:
+Normal armor absorbs 1/3 of damage you receive. Absorption is rounded down:
 if you have 100 health and 100 armor and are hit for 50 damage, you'll lose
 34 health and 16 armor.
 
@@ -457,7 +462,7 @@ access to shortcuts or secret areas.
 
 Freedoom's keys are designed to be distinguishable not just by color but
 also by shape, to make the game more accessible to color-blind players.
-Each key color has an associated unique shape:
+Each key color has an associated shape:
 
 [cols="2,3",width="50%",align="center",valign="middle"]
 |==========================
@@ -467,8 +472,8 @@ Each key color has an associated unique shape:
 | Red | Horizontal lines
 |==========================
 
-These shapes are used consistently throughout the game: in the status bar
-icons, the key sprites and on walls indicating keyed doors.
+These shapes are used consistently in the status bar icons,
+the key sprites and on walls indicating keyed doors.
 
 For the skeleton keys, pay attention to the direction that the horns point.
 For example, here is how the different key icons appear in the status bar:
@@ -484,40 +489,46 @@ You may also encounter any one of these special items while exploring:
 |==========================
 | **Low-Light Goggles** +
 image:../sprites/pvisa0.png[Low-Light Goggles] |
-Allow you to see in the dark for a limited time.
+Let you see in the dark. +
+Effect lasts 2 minutes.
 | **Area Survey Map** +
 image:../sprites/pmapa0.png[Area Survey Map] |
 Reveals unexplored areas of the map, including some secret areas that
-may not be immediately visible.
+may not be immediately visible. +
+Effective for the entire level and that level only.
 | **Rescue Operations Suit** +
 image:../sprites/suita0.png[Rescue Operations Suit] |
-Protects you from heat, toxins and radiation from damaging floors,
-for a limited time.
+Protects you from heat, toxins and radiation from damaging floors. +
+Lasts 1 minute.
 | **Strength Symbiote** +
 image:../sprites/pstra0.png[Strength Symbiote] |
 Increases your health back to 100%, and enhances your fists to 10x their
-normal damage until the end of level.
+normal damage. +
+Health is permanent; damage increase lasts only for that level. +
 | **Invisibility Cloak** +
 image:../sprites/pinsa0.png[Invisibility Cloak] |
-Makes you almost invisible for a limited time. Monsters still detect
-your presence, but they'll find it much harder to aim.
+Makes you almost invisible. Monsters still detect
+your presence, but they'll find it much harder to aim. +
+Lasts 1 minute.
 | **Negentropic Surge** +
 image:../sprites/megaa0.png[Negentropic Surge] |
-Maxes you out to 200% health and armor.
+Maxes you out to 200% health+armor. +
+Permanent.
 | **Vanguard Device** +
 image:../sprites/pinva0.png[Vanguard Device] |
-Makes you immune to all damage for a limited time, allowing you to get
-past overwhelming defences and unavoidable traps.
+Makes you immune to all damage, allowing you to get
+past overwhelming defences and unavoidable traps. +
+Lasts 30 seconds.
 |==========================
 
 [[enemies]]
 === Enemies
 
-The levels are filled with monsters who have no other goal apart from stopping
+The levels are filled with monsters who have no goal apart from stopping
 you from completing your mission. Here’s a selection of some of these monsters
 who you can expect to encounter.
 
-[frame="none",cols="2,1",valign="middle",grid="none",align="center",width="100%"]
+[frame="none",cols="5,2",valign="middle",grid="none",align="center",width="100%"]
 |==========================
 | **Zombie** +
 These brain-dead workers of iniquity are armed with a handgun and intent on
@@ -541,11 +552,11 @@ Tough and fast-moving, these worms attack at close range and take several
 shotgun blasts to take down. It’s best to keep back. |
 image:images/monster-flesh-worm.png[Flesh Worm,100,100,width=100%]
 | **Stealth Worm** +
-These flesh worm variants have been given stealth abilities which make them
-practically invisible. |
+Some flesh worms can bend light around them, making them
+nearly invisible in darker and noisier environments. |
 image:images/monster-stealth-worm.png[Stealth Worm,100,100,width=100%]
 | **Hatchling** +
-Floating alien larvae which charge from a distance. |
+Ionized alien larvae that bodyslam you for surprising amounts of damage. |
 image:images/monster-hatchling.png[Hatchling,100,100,width=100%]
 | **Matribite** +
 What sick mother sends her own babies to fight? Thus is the duty of empire. |
@@ -570,8 +581,8 @@ If he’s not setting you on fire, he’s undoing all your hard work by bringing
 his friends back from the dead. |
 image:images/monster-necromancer.png[Necromancer,100,100,width=100%]
 | **Combat Slug** +
-These genetically-engineered flesh monsters have been fitted with long distance
-flame throwers, making them into living, slithering tanks. |
+These genetically-engineered living, slithering tanks have been fitted
+with long distance flame throwers. |
 image:images/monster-combat-slug.png[Combat Slug,100,100,width=100%]
 | **Technospider** +
 These cybernetic creatures fire high-capacity polaric energy support weapons,
@@ -609,8 +620,8 @@ Areas of the map are usually color coded as follows:
 if the <<specialitems,Tactical Survey Map>> item is discovered).
 |==========================
 
-While using the map, the game continues as normal. Controls continue
-to work as usual, but the following additional keys are available:
+While using the map, the game continues as normal. Controls work as usual,
+in addition to the following:
 
 [frame="none",cols="1,4",valign="middle",align="center",width="80%"]
 |==========================
@@ -618,11 +629,11 @@ to work as usual, but the following additional keys are available:
 | **-** | Zoom out.
 | **+** | Zoom in.
 | **0** | Maximum zoom out.
-| **F** | Toggle whether the map follows the player. When disabled, the
-cursor keys can be used to pan the view of the map around independent of
-your current position.
+| **F** | Toggle whether the map follows the player. When turned off,
+you can use the cursor keys to pan the view of the map around independent
+of your current position.
 | **G** | Toggle map grid.
-| **M** | Add a map bookmark at the current location.
+| **M** | Add map bookmark at your position.
 | **C** | Clear all bookmarks.
 |==========================
 
@@ -643,8 +654,8 @@ image:images/hazard-barrels.png[Barrels,150,150,width=100%]
 | **Damaging Floors** |
 Red-hot lava and radioactive sludge are just two of the types of damaging floor
 you can encounter in Freedoom’s levels. If walking over it is necessary, try to
-find yourself a <<specialitems,rescue suit>>, but be aware that it will only
-protect you for a limited time. |
+find yourself a <<specialitems,rescue suit>>, a shorter path through the area,
+or way to run over the area without touching the floor. |
 image:images/hazard-slime.png[Radioactive slime,150,150,width=100%]
 | **Crushing Ceilings** |
 Many of the levels have been rigged with traps and this is just one of them.
@@ -701,7 +712,7 @@ into some of these suggestions:
   shooting long enough for you to return fire. Monsters with guns are also
   not any better or worse at hitting you whether you are moving or standing
   still, so you can't continuously dodge on open ground the
-  way you can against visibly moving projectiles.
+  way you can against visible projectiles.
 
 * Many of the levels are littered with exploding barrels. While these can pose
   a danger to you, they’re equally dangerous to your opponents. A single,
@@ -742,16 +753,13 @@ image::images/scythe-map09.png[Scythe MAP09,width="640",pdfwidth="70vw",align="c
 
 One of the nicest features of Freedoom is its compatibility with the
 catalog of thousands of fan-made levels made for the classic _Doom_ games.
-With some exceptions, most popular mods and levels for _Doom_ and _Doom II_
+Most popular mods and levels for _Doom_ and _Doom II_
 can also be played with Freedoom.
-The largest repository of _Doom_ mods is the idgames archive, and a
-browsing interface for the archive
-https://www.doomworld.com/idgames/[can be found on Doomworld].
 
-Playing a `.wad` file is usually fairly simple. For mods designed for the
-original _Doom_, use Freedoom: Phase 1 (`freedoom1.wad`); for others designed
-for _Doom 2_ or _Final Doom_, use Freedoom: Phase 2 (`freedoom2.wad`).
-If you’re using the command line, use the `-file` parameter when you start the
+For mods designed for the original _Doom_, use Freedoom: Phase 1
+(`freedoom1.wad`); for others designed for _Doom 2_ or _Final Doom_,
+use Freedoom: Phase 2 (`freedoom2.wad`). If you’re using the command
+line, use the `-file` parameter when you start the
 game. For example, to load the file `scythe.wad`:
 
   my-favorite-port -iwad freedoom2.wad -file scythe.wad
@@ -760,7 +768,7 @@ If you’re not using the command line, you can try dragging and dropping the
 `.wad` file onto the source port icon in your file manager -- several
 source ports support this.
 
-=== Suggestions
+=== Suggested resources
 
 Over more than two decades, literally thousands of _Doom_ levels have been
 made, and there are so many that it may seem difficult to know where to
@@ -778,10 +786,8 @@ recent developments, including some of the more unusual mods that people
 are releasing.
 
 * The Doom Wiki’s https://doomwiki.org/wiki/List_of_notable_WADs[List of
-notable WADs] contains a rather extensive list of fan-made WADs. The Doom
-Wiki includes extensive information about such mods including screenshots,
-maps and per-level statistics, so it’s a useful entrypoint to discover
-interesting mods.
+notable WADs] contains an extensive list of fan-made WADs and includes
+screenshots, maps and per-level statistics.
 
 * Doomworld’s interface to the idgames archive includes the ability to
 list the https://www.doomworld.com/idgames/index.php?top[top levels] based
@@ -791,17 +797,16 @@ on five star rankings by visitors to the site.
 
 == Cheats ==
 
-If you’re finding the game too difficult, you can always try playing at
-an <<skill,easier skill level>>. However, if that’s not enough, or if you
-just want to experiment with the game mechanics, there are a
-number of cheats that you can turn to:
+If you can't get through a spot regardless of <<skill,skill level>>,
+or if you just want to experiment with game mechanics, try typing any
+of these ingame (case insensitive, do not use any console):
 
 [cols="2,4",width="90%",align="center",valign="middle"]
 |==========================
-| **IDDQD** | God mode. Makes you invulnerable to all damage.
+| **IDDQD** | God mode. You take no damage other than telefrags.
 | **IDFA** | Gives all weapons and ammo.
 | **IDKFA** | Gives all weapons, ammo and keys.
-| **IDCLIP** | Noclip mode, which lets you walk through walls.
+| **IDCLIP** | Noclip mode. You are not stopped by collisions with walls or actors.
 | **IDDT** | Reveals full map; type twice to reveal all enemies and items.
 | **IDCLEVxy** | Starts a new game (which resets everything) on ExMy (Phase 1) or MAPxy (Phase 2).
 | **IDMUSxy** | Change music to that of ExMy (Phase 1) or MAPxy (Phase 2).
@@ -865,16 +870,26 @@ rights (free as in free speech) to end users, provided that the original
 software license is included and/or viewable by users of modified or
 redistributed versions.
 
-If you’d like to contribute to the Freedoom project, please check out the
-https://github.com/freedoom/freedoom[project’s page],
-https://www.doomworld.com/forum/17-freedoom/[discussion forum],
-and https://discord.gg/9DA3fut[discord chat].
+If you’d like to contribute to the Freedoom project, please check out
+the following community hubs:
 
-https://help.github.com/en/github[How to use Git version control for contributions]
+* Freedoom's source repository: +
+https://github.com/freedoom/freedoom
 
-https://guides.github.com/activities/forking/[How to fork a project and create a pull request with Git]
+* the Freedoom discussion forum on Doomworld: +
+https://www.doomworld.com/forum/17-freedoom/
 
-<<<
+* the Discord guild: +
+https://discord.gg/9DA3fut
+
+For more information on how to submit an addition, please see the following pages on how to use GitHub:
+
+* How to use Git version control for contributions: +
+https://help.github.com/en/github
+
+* How to fork a project and create a pull request with Git: +
+https://guides.github.com/activities/forking/
+
 
 [[reusing]]
 == Reusing portions of Freedoom ==
@@ -883,4 +898,38 @@ Since https://freedoom.github.io/about.html[Freedoom is free], some other
 projects have used Freedoom’s assets.  We think this is a great use of the
 project and should be encouraged. If you use portions of Freedoom in your
 project, please let us know by filing an issue or pull request on
-https://github.com/freedoom/freedoom.github.io[Freedoom’s website project page].
+Freedoom’s website project page at https://github.com/freedoom/freedoom.github.io.
+
+[[licence]]
+=== BSD 3-Clause copyright licence
+
+Copyright © 2001-2023
+Contributors to the Freedoom project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the Freedoom project nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS
+IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For a list of contributors to the Freedoom project, see the file
+CREDITS.


### PR DESCRIPTION
Some of the table columns were not large enough to fit the text, or the words themselves were too big when smaller words would have done.

Lots of single-word lines at the ends of paragraphs.

Removed a bit of redundant information.

Vital links in the submitting/visiting sections needed to have visible URLs in case one really did print them out.

Added a copy of the BSD licence and a link to the website.

Zip of built PDFs in English and Spanish showing before and after:
[man.zip](https://github.com/freedoom/freedoom/files/13447785/man.zip)

Controls table now unjanked (EDIT: the unspaced slash line spillovers in Spanish are also fixed, just too lazy to update the screenshot)
![2023-11-23-011751_1600x900_scrot](https://github.com/freedoom/freedoom/assets/24984517/cc5f6e1b-5390-420f-becb-e0f8c3250d00)
![2023-11-23-011836_1600x900_scrot](https://github.com/freedoom/freedoom/assets/24984517/7dcd5940-985d-445d-acee-8192d1121666)

Menu items, keyboard shortcuts, cheats all now on one page
![2023-11-23-011455_1600x900_scrot](https://github.com/freedoom/freedoom/assets/24984517/976ae352-5dae-44fe-a86e-c28a13bcbb9e)
![2023-11-23-011511_1600x900_scrot](https://github.com/freedoom/freedoom/assets/24984517/b4c4a52d-c274-41c8-9d3b-2caa2224db47)
![2023-11-23-011616_1600x900_scrot](https://github.com/freedoom/freedoom/assets/24984517/302526cb-a39f-46dc-9eba-a24fd27a7ad9)

Enemies section more compact
![2023-11-23-011554_1600x900_scrot](https://github.com/freedoom/freedoom/assets/24984517/3cac4322-e7b2-4fe9-b9a0-13daba6dcebe)

Front page more information-dense
![2023-11-23-011427_1600x900_scrot](https://github.com/freedoom/freedoom/assets/24984517/faed936d-e4af-4cfc-b0a6-025316ca2d69)
