### PR TITLE
manual: Fix warning in tutorial steps 1-15

### DIFF
--- a/manual/manual-fr.adoc
+++ b/manual/manual-fr.adoc
@@ -182,48 +182,48 @@ Ce tutoriel vous présentera toutes les actions de base dont vous aurez besoin p
 
 Commencez une nouvelle partie dans Freedoom Phase 1, épisode 1 sur le niveau de difficulté facile et suivez les étapes. Ignorez tout ce qui vous ennuie ou vous embrouille, et refaites tout ce que vous trouvez difficile aussi longtemps que vous le souhaitez, avant de passer à l'étape suivante ou de refaire une étape précédente.
 
-1. Essayez de vous déplacer en avant, en arrière, à gauche, et à droite.
+. Essayez de vous déplacer en avant, en arrière, à gauche, et à droite.
   Tracez un carré. Essayez de le faire dans le sens horaire et antihoraire. Essayez de faire le numéro huit. (Ne quittez pas la cage pour l'instant -- il y a des monstres à l'extérieur.)
 
-1. Tournez en rond pour examiner votre environnement. Faites-le à votre propre
+. Tournez en rond pour examiner votre environnement. Faites-le à votre propre
   rythme, en vous arrêtant ou en changeant de direction pour regarder n'importe où quand vous voulez. Faites un deuxième cercle, en vous déplaçant un peu au fur à mesure, et observez comment cela change la perspective et comment le mouvement latéral peut vous aider à voir la longueur d'un mur ou la distance d'un objet.
 
-1. Retournez au milieu de la cage. Tournez et pointez votre pistolet
+. Retournez au milieu de la cage. Tournez et pointez votre pistolet
   sur l'une des colonnes du cadre de porte.
 
-1. Déplacez-vous -- sans tourner -- afin que votre pistolet soit pointé vers 
+. Déplacez-vous -- sans tourner -- afin que votre pistolet soit pointé vers 
   l'autre colonne. (Idéalement, essayez de vous arrêter naturellement sur la cible.)
 
-1. Déplacez-vous un peu à gauche ou à droite, puis tournez à nouveau pour
+. Déplacez-vous un peu à gauche ou à droite, puis tournez à nouveau pour
   pointer vers la colonne. Recommencez, mais tournez avant que votre élan ne s'estompe. Recommencez quelques fois, en utilisant les quatre directions et en tournant de plus en plus tôt jusqu'à ce que vous pointiez et que vous vous déplaciez de façon fluide. (Reculez ou avancez pour réinitialiser si vous vous approchez trop ou si vous courez dans les murs.)
 
-1. Essayez de faire un carré (ou le numéro huit, etc.) tout en pointant
+. Essayez de faire un carré (ou le numéro huit, etc.) tout en pointant
   vers la colonne en même temps. Privilégiez la fluidité au lieu de la précision -- il vaut mieux être proche la plupart du temps que rarement parfait.
 
-1. Déplacez-vous sur un des lits dans les coins afin que la colonne ne
+. Déplacez-vous sur un des lits dans les coins afin que la colonne ne
   soit plus visible. Déplacez-vous afin que la colonne entre et sorte de vue. Expérimentez avec la distance et le timing. Ensuite, tentez de pointer vers la colonne même si vous ne pouvez pas la voir.
 
-1. Jouez un peu avec ce qui a été dit précédemment. Essayez d'appuyer
+. Jouez un peu avec ce qui a été dit précédemment. Essayez d'appuyer
   sur la touche Tirer pour tirer sur la colonne en restant immobile et en vous déplaçant, observez où et quand un petit nuage de fumée se forme. (Arrêtez de tirer avant que votre nombre de munitions tombe en dessous de 30 -- vous en aurez besoin pour plus tard !)
 
-1. Appuyez sur la touche 1 du clavier pour passer à vos poings, et
+. Appuyez sur la touche 1 du clavier pour passer à vos poings, et
   tentez de frapper la colonne et observez jusqu'à quelle distance vous pouvez le faire. Appuyez sur la touche 2 pour retourner à votre pistolet.
 
-1. Maintenant vérifiez si vous pouvez accomplir toutes les tâches
+. Maintenant vérifiez si vous pouvez accomplir toutes les tâches
   tout en maintenant la touche Courir enfoncée.
 
-1. Descendez dans la tranchée et tuez un <<enemies,zombie>>. Essayez
+. Descendez dans la tranchée et tuez un <<enemies,zombie>>. Essayez
   de ne pas prendre de dégâts.
 
-1. Une fois en sécurité, regardez près du corps du zombie pour voir
+. Une fois en sécurité, regardez près du corps du zombie pour voir
   s'il a laissé tomber un <<ammo,chargeur>>. Si oui, déplacez-vous pour le ramasser.
 
-1. Retournez en arrière d'où vous venez. Allez à l'ascenseur comme
+. Retournez en arrière d'où vous venez. Allez à l'ascenseur comme
   si vous alliez le frapper, puis appuyez sur la touche Utiliser pour l'appeler. Montez dessus et il vous sortira de la tranchée. Ramassez les objets dans la zone supérieure pour rétablir ou booster votre santé.
 
-1. Explorez le reste de la zone. Vous trouverez deux portes qui peuvent être utilisées directement, comme l'ascenseur. La porte du bas vous mènera vers un chemin plus proche de la sortie, tandis que celle du haut vous mènera vers un chemin plus dur mais également plus gratifiant.
+. Explorez le reste de la zone. Vous trouverez deux portes qui peuvent être utilisées directement, comme l'ascenseur. La porte du bas vous mènera vers un chemin plus proche de la sortie, tandis que celle du haut vous mènera vers un chemin plus dur mais également plus gratifiant.
 
-1. Une fois que vous avez fait votre choix, ouvrez la porte et préparez-vous à utiliser le savoir que vous avez acquis.
+. Une fois que vous avez fait votre choix, ouvrez la porte et préparez-vous à utiliser le savoir que vous avez acquis.
 
 <<<
 

--- a/manual/manual.adoc
+++ b/manual/manual.adoc
@@ -227,63 +227,63 @@ Skip anything that bores or confuses you, and redo anything you find
 challenging as long as you like, before moving on to the next thing or
 redoing a previous thing.
 
-1. Try moving forward, backward, left, and right.
+. Try moving forward, backward, left, and right.
   Trace a square. Try both directions. Try doing a figure eight.
   (Don't leave the cage yet -- there are monsters outside.)
 
-1. Turn around in a circle to examine your surroundings. Go at your own pace,
+. Turn around in a circle to examine your surroundings. Go at your own pace,
   stopping or reversing to look at anything whenever you want.
   Do a second circle, moving a little bit as you go, and watch how that
   changes the perspective and how sideways movement can help you see
   how long a wall or how far away an object is.
 
-1. Move back to the middle of the cage. Turn to point your handgun
+. Move back to the middle of the cage. Turn to point your handgun
   directly at one of the doorframe columns.
 
-1. Move -- without turning -- so that your handgun is pointed at the other column.
+. Move -- without turning -- so that your handgun is pointed at the other column.
  (Bonus points if you can come to a natural stop on target.)
 
-1. Move a bit left or right, then turn to point at the column again.
+. Move a bit left or right, then turn to point at the column again.
   Do it again, but start turning before your momentum wears off.
   Do this again a few times, cycling through all four directions and turning
   sooner and sooner until you are pointing and the moving seamlessly.
   (Move backwards or forwards to reset if you start running into walls.)
 
-1. Try doing a square (or figure eight, etc.) while pointing at the column
+. Try doing a square (or figure eight, etc.) while pointing at the column
   the entire time. Prioritize smoothness over precision -- it's better to
   be close most of the time than perfect some of the time.
 
-1. Move to one of the corners with the beds on them so that the column is
+. Move to one of the corners with the beds on them so that the column is
   no longer in your line of sight. Move in and out of sight with
   the column playing "Peek-A-Boo" with it. Mess with distance and timing.
   Try to stay pointed at the column even when you can't see it.
 
-1. Play around with the above for a bit. Try pressing the Fire key to shoot at
+. Play around with the above for a bit. Try pressing the Fire key to shoot at
   the column, both standing still and moving, and note where and when
   the bullet puffs appear. (Stop shooting before your ammo count goes below
   30 or so -- you will need those for later!)
 
-1. Tap the 1 key on the keyboard to switch to your fist, and try to punch the
+. Tap the 1 key on the keyboard to switch to your fist, and try to punch the
   column and see how far away you can do it. Tap the 2 key to switch back
   to the handgun.
 
-1. Try to do everything while holding down the Run key.
+. Try to do everything while holding down the Run key.
 
-1. Enter the trench and kill a <<enemies,zombie>>. Try not to get hit.
+. Enter the trench and kill a <<enemies,zombie>>. Try not to get hit.
 
-1. Once you're safe, look near the zombie's body to see if it may have left
+. Once you're safe, look near the zombie's body to see if it may have left
   a <<ammo,clip>>. If it has, move over it to pick it up.
 
-1. Go back the way you came. Go up to the lift like you're going to punch it,
+. Go back the way you came. Go up to the lift like you're going to punch it,
   then hit Use to call it down. Get on it and it will take you back up.
   Pick up the items in the upper area to restore or boost your health.
 
-1. Explore the rest of the area. You will find two doors, which can be
+. Explore the rest of the area. You will find two doors, which can be
   opened with the Use key just like the lift. The lower door will take you
   closer to the exit, while the higher one leads to a more
   difficult but more rewarding detour.
 
-1. Once you've decided which way to go, open the door -- and get ready
+. Once you've decided which way to go, open the door -- and get ready
   to start playing Gun Peek-A-Boo again...
 
 <<<


### PR DESCRIPTION
asciidoctor-pdf outputs a warning when ordered lists are numbered entirely with "1.". It wants actual consecutive integers. Prior to this fix there were 14 warnings such as:
  asciidoctor: WARNING: manual.adoc: line 234: list item index: expected 2, got 1
in the English and French manual. Interestingly it amkes no difference in the PDF produced, but let's minimize the number of warnings in the build.

----

I know we talked about this, mc776. I'm hoping you don't object on principle (the principle being that asciidoctor-pdf shouldn't have such a warning because it makes lists harder to maintain, like you said) since it adds 28 warnings to `make dist` and `make install`. And there's something to be said for being explicit as well.