### PR TITLE
build: Add processing for "CREDITS-MUSIC"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ doom.gpl
 
 /COPYING.txt
 /CREDITS.txt
+/CREDITS-MUSIC.txt
 
 /bootstrap/*.wad
 

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ gimp-palette: doom.gpl
 
 clean:
 	$(RM) *.html doom.gpl $(OBJS) \
-	      ./COPYING.txt ./CREDITS.txt \
+	      ./COPYING.txt ./CREDITS.txt ./CREDITS-MUSIC.txt \
 	      ./wadinfo_phase1.txt \
 	      ./wadinfo_phase2.txt \
 	      ./wadinfo_freedm.txt \
@@ -260,7 +260,7 @@ install-freedm: $(FREEDM) $(HTMLDOCS) manual/freedoom-manual.pdf \
 	install -Dm 644 $(FREEDM) -t "$(target)$(waddir)"
 	install -Dm 644 dist/io.github.freedoom.FreeDM.png \
 	                -t "$(target)/share/icons"
-	install -Dm 644 CREDITS NEWS.html README.html -t "$(target)$(docdir)/freedm"
+	install -Dm 644 CREDITS CREDITS-MUSIC NEWS.html README.html -t "$(target)$(docdir)/freedm"
 	install -Dm 644 COPYING.adoc "$(target)$(docdir)/freedm/COPYING"
 	-install -Dm 644 manual/freedoom-manual.pdf -t "$(target)$(docdir)/freedm"
 
@@ -285,7 +285,7 @@ install-freedoom: $(FREEDOOM1) $(FREEDOOM2) $(HTMLDOCS)                 \
 	                -t "$(target)/share/icons"
 	install -Dm 644 dist/io.github.freedoom.Phase2.png \
 	                -t "$(target)/share/icons"
-	install -Dm 644 CREDITS NEWS.html README.html \
+	install -Dm 644 CREDITS CREDITS-MUSIC NEWS.html README.html \
 	                -t "$(target)$(docdir)/freedoom"
 	install -Dm 644 COPYING.adoc "$(target)$(docdir)/freedoom/COPYING"
 	-install -Dm 644 manual/freedoom-manual.pdf -t "$(target)$(docdir)/freedoom"
@@ -299,6 +299,7 @@ uninstall-freedm:
 	      "$(target)$(mandir)/man6/freedm.6"                                \
 	      "$(target)$(waddir)/freedm.wad"                                   \
 	      "$(target)$(docdir)/freedm/CREDITS"                               \
+	      "$(target)$(docdir)/freedm/CREDITS-MUSIC"                         \
 	      "$(target)$(docdir)/freedm/COPYING"                               \
 	      "$(target)$(docdir)/freedm/NEWS.html"                             \
 	      "$(target)$(docdir)/freedm/README.html"                           \
@@ -323,6 +324,7 @@ uninstall-freedoom:
 	      "$(target)$(waddir)/freedoom1.wad"                                \
 	      "$(target)$(waddir)/freedoom2.wad"                                \
 	      "$(target)$(docdir)/freedoom/CREDITS"                             \
+	      "$(target)$(docdir)/freedoom/CREDITS-MUSIC"                       \
 	      "$(target)$(docdir)/freedoom/COPYING"                             \
 	      "$(target)$(docdir)/freedoom/NEWS.html"                           \
 	      "$(target)$(docdir)/freedoom/README.html"                         \


### PR DESCRIPTION
Fix those places where "CREDITS-MUSIC" did not have the same processing as "CREDITS".

---

This means that `make dist` and `make install` will now include `CREDITS-MUSIC` where they had previously included only `CREDITS`.