### PR TITLE
[Draft] New par times are needed for maps

### DIFF
--- a/lumps/dehacked/dehacked.txt
+++ b/lumps/dehacked/dehacked.txt
@@ -55,24 +55,24 @@ par  1 1   30  # 00:30 - Voros for v0.12 - 2017/03
 par  1 2  120  # 02:00 - Voros for v0.12 - 2017/03
 par  1 3  150  # 02:30 - Voros for v0.12 - 2017/03
 par  1 4  180  # 03:00 - Voros for v0.12 - 2017/03
-par  1 5   90  # 01:30 - Voros for v0.12 - 2017/03
+par  1 5   90  # 01:30 - Voros for v0.12 - 2017/03            # 0.12 E1M9 par
 par  1 6  390  # 06:30 - Voros for v0.12 - 2017/03
 par  1 7  690  # 11:30 - Voros for v0.12 - 2017/03
 par  1 8   60  # 01:00 - Voros for v0.12 - 2017/03
 par  1 9  240  # 04:00 - m for v0.13 - 2023/04
-par  2 1  120  # 02:00 - Voros for v0.12 - 2017/03
-par  2 2  150  # 02:30 - Voros for v0.12 - 2017/03
-par  2 3  180  # 03:00 - Voros for v0.12 - 2017/03
-par  2 4  270  # 04:30 - Voros for v0.12 - 2017/03
-par  2 5  300  # 05:00 - Voros for v0.12 - 2017/03
-par  2 6  150  # 02:30 - Voros for v0.12 - 2017/03
-par  2 7  120  # 02:00 - Voros for v0.12 - 2017/03
+par  2 1    0  # 00:00
+par  2 2    0  # 00:00
+par  2 3    0  # 00:00
+par  2 4    0  # 00:00
+par  2 5  180  # 03:00 - Voros for v0.12 - 2017/03            # 0.12 E2M3 par
+par  2 6  270  # 02:30 - Voros for v0.12 - 2017/03            # 0.12 E2M4 par
+par  2 7    0  # 00:00
 par  2 8  120  # 02:00 - Voros for v0.12 - 2017/03
-par  2 9  360  # 06:00 - Voros for v0.12 - 2017/03
+par  2 9  300  # 05:00 - Voros for v0.12 - 2017/03            # 0.12 E2M5 par           
 par  3 1   30  # 00:30 - Voros for v0.12 - 2017/03
-par  3 2  120  # 02:00 - Voros for v0.12 - 2017/03
-par  3 3  240  # 04:00 - Voros for v0.12 - 2017/03
-par  3 4  270  # 04:30 - Voros for v0.12 - 2017/03
+par  3 2  240  # 04:00 - Voros for v0.12 - 2017/03            # 0.12 E3M3 par
+par  3 3  270  # 04:30 - Voros for v0.12 - 2017/03            # 0.12 E3M4 par
+par  3 4    0  # 00:00
 par  3 5    0  # 00:00
 par  3 6  180  # 03:00 - Voros for v0.12 - 2017/03
 par  3 7  300  # 05:00 - Voros for v0.12 - 2017/03
@@ -84,8 +84,8 @@ par  2   90  # 01:30  - Voros for v0.11 - 2017/02
 par  3  120  # 02:00  - Voros for v0.11 - 2017/02
 par  4  120  # 02:00  - Voros for v0.11 - 2017/02
 par  5  150  # 02:30  - Voros for v0.11 - 2017/02
-par  6  90   # 01:30  - Voros for v0.11 - 2017/02
-par  7  150  # 02:30  - Voros for v0.11 - 2017/02
+par  6  195  # 03:15  - uni for v0.13 - 2024/01
+par  7  270  # 02:30  - uni for v0.13 - 2024/01
 par  8  330  # 05:30  - Voros for v0.11 - 2017/02
 par  9  150  # 02:30  - Voros for v0.11 - 2017/02
 par 10  120  # 02:00  - Voros for v0.11 - 2017/02
@@ -96,16 +96,16 @@ par 14  150  # 02:30  - Voros for v0.11 - 2017/02
 par 15  510  # 08:30  - Voros for v0.11 - 2017/02
 par 16  120  # 02:00  - Voros for v0.11 - 2017/02
 par 17  120  # 02:00  - Voros for v0.11 - 2017/02
-par 18  180  # 03:00  - Voros for v0.11 - 2017/02
+par 18  90   # 01:30  - Voros for v0.11 - 2017/02             # 0.11 MAP06 par
 par 19  210  # 03:30  - Voros for v0.11 - 2017/02
 par 20  420  # 07:00  - Voros for v0.11 - 2017/02
-par 21  330  # 05:30  - Voros for v0.11 - 2017/02
+par 21    0  # 00:00
 par 22  420  # 07:00  - Voros for v0.11 - 2017/02
 par 23  240  # 04:00  - Voros for v0.11 - 2017/02
-par 24  420  # 07:00  - Catoptromancy OLD run for v0.7
+par 24    0  # 00:00
 par 25  600  # 10:00  - Voros for v0.11 - 2017/02
-par 26  270  # 04:30  - Voros for v0.11 - 2017/02
-par 27  690  # 11:30  - Voros for v0.11 - 2017/02
+par 26    0  # 00:00
+par 27    0  # 00:00
 par 28  450  # 07:30  - Voros for v0.11 - 2017/02
 par 29  300  # 05:00  - Voros for v0.11 - 2017/02
 par 30   60  # 01:00  - Voros for v0.11 - 2017/02

--- a/lumps/dehacked/dehacked.txt
+++ b/lumps/dehacked/dehacked.txt
@@ -85,7 +85,7 @@ par  3  120  # 02:00  - Voros for v0.11 - 2017/02
 par  4  120  # 02:00  - Voros for v0.11 - 2017/02
 par  5  150  # 02:30  - Voros for v0.11 - 2017/02
 par  6  195  # 03:15  - uni for v0.13 - 2024/01
-par  7  270  # 02:30  - uni for v0.13 - 2024/01
+par  7  270  # 04:30  - uni for v0.13 - 2024/01
 par  8  330  # 05:30  - Voros for v0.11 - 2017/02
 par  9  150  # 02:30  - Voros for v0.11 - 2017/02
 par 10  120  # 02:00  - Voros for v0.11 - 2017/02


### PR DESCRIPTION
These haven't been touched for a while:

I've shuffled the par times accordingly to the maps moving during development.
New par times are needed for new levels. (set to 0 for now, waiting for new demos for par times)

Surprised a new par time wasn't done for MAP24 since 0.7.
The old E3M5/current E3M4 never had a par time done for it.
MAP11 might also need to be redone with the level rework.

I've done two of my own UV-Max demos for MAP06 and MAP07 with the times being rounded to the nearest quarter-minute. ([here](https://www.dropbox.com/scl/fi/05snaswis5qzosl7l3zdc/newpar.zip?rlkey=ny54718shxl7afed313bbrws6&dl=0))

I would recommend UV-Max for par times for larger, more "newbie-accurate" times but that's just an opinion.