### PR TITLE
Remove reference to old MAP31 in DeHackEd

### DIFF
--- a/lumps/dehacked/dehacked.txt
+++ b/lumps/dehacked/dehacked.txt
@@ -589,7 +589,9 @@ C5TEXT = You step into the teleporter. You feel a\n\
          You'd rather not find out.
 # Before MAP32 (secret level #2):
 C6TEXT = Forcibly uncaged again. Good job.\n\n\
-         But where are you? This... this isn't the city?!\n\n\
+         But where are you? The air and gravity\n\
+         still feel like whatever planet that\n\
+         strange prison had been on.\n\n\
          You look around and the layout triggers\n\
          some old memories from history class.\n\n\
          This is an arena.\n\

--- a/lumps/dehacked/dehacked.txt
+++ b/lumps/dehacked/dehacked.txt
@@ -589,9 +589,8 @@ C5TEXT = You step into the teleporter. You feel a\n\
          You'd rather not find out.
 # Before MAP32 (secret level #2):
 C6TEXT = Forcibly uncaged again. Good job.\n\n\
-         But where are you? The air and gravity\n\
-         still feel like whatever hell-rock that\n\
-         strange prison had been on.\n\n\
+         But where are you?  It seems you took\n
+         a wrong turn.\n\n\
          You look around and the layout triggers\n\
          some old memories from history class.\n\n\
          This is an arena.\n\

--- a/lumps/dehacked/dehacked.txt
+++ b/lumps/dehacked/dehacked.txt
@@ -589,8 +589,7 @@ C5TEXT = You step into the teleporter. You feel a\n\
          You'd rather not find out.
 # Before MAP32 (secret level #2):
 C6TEXT = Forcibly uncaged again. Good job.\n\n\
-         But where are you?  It seems you took\n
-         a wrong turn.\n\n\
+         But where are you? This... this isn't the city?!\n\n\
          You look around and the layout triggers\n\
          some old memories from history class.\n\n\
          This is an arena.\n\


### PR DESCRIPTION
The DeHackEd text for the MAP31 to 32 secret exit still mentions "Safety in Numbers" - 0.10 and before's MAP31.

> hell-rock that strange prison had been on.
![Screenshot_Doom_20240129_160025](https://github.com/freedoom/freedoom/assets/139153158/f503f269-0939-4f41-94bc-21494d3fc80c)


This could most likely be worded better.