### PR TITLE
NEWS: Add octaminator to NEWS.adoc

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -26,6 +26,7 @@
   * New minigunner.
   * The hatchling, which replaces the deadflare.
   * The matribite, which replaces the summoner.
+  * The octaminator, which replaces the dark soldier.
 
 === Music
   * Lots of new music including most of FreeDM music.


### PR DESCRIPTION
Unfortunately I overlooked adding this wonderful new monster to NEWS.adoc for 0.13.0.

---

The downloadable ZIP files have already been tagged, so I don't think we should mess with them, but there's no reason that `NEWS.adoc` can't be retroactively made accurate in `master` for previous releases.

I can update the website with this change once it's merged.