### PR TITLE
dist: update screenshots on metainfo XML files.

### DIFF
--- a/dist/io.github.freedoom.FreeDM.metainfo.xml
+++ b/dist/io.github.freedoom.FreeDM.metainfo.xml
@@ -39,19 +39,19 @@
   </content_rating>
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/tn_dm_1.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_dm_1.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_dm_2.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_dm_2.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_dm_7.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_dm_7.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_dm_8.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_dm_8.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>

--- a/dist/io.github.freedoom.FreeDM.metainfo.xml
+++ b/dist/io.github.freedoom.FreeDM.metainfo.xml
@@ -39,20 +39,20 @@
   </content_rating>
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/freedm-gzdoom-dm01-banner-0.13.0.png</image>
-      <caption>DM01: Tech Test</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_dm_1.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/freedm-gzdoom-dm06-exit-0.13.0.png</image>
-      <caption>DM06: Temple of Ammon</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_dm_2.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/freedm-gzdoom-dm21-banner-0.13.0.png</image>
-      <caption>DM21: Refinery</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_dm_7.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/freedm-gzdoom-dm22-corner-0.13.0.png</image>
-      <caption>DM22: Fourplay</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_dm_8.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>
   <releases>

--- a/dist/io.github.freedoom.Phase1.metainfo.xml
+++ b/dist/io.github.freedoom.Phase1.metainfo.xml
@@ -39,20 +39,20 @@
   </content_rating>
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/phase1-gzdoom-e1m6-upstairs-0.13.0.png</image>
-      <caption>E1M6: Training Facility</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_p1_1.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/phase1-gzdoom-e2m8-tripods-0.13.0.png</image>
-      <caption>E2M8: Containment Cell</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_p1_2.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/phase1-gzdoom-e3m1-trilobites-worms-0.13.0.png</image>
-      <caption>E3M1: Land of the Lost</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_p1_7.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/phase1-gzdoom-e3m3-pain-lord-0.13.0.png</image>
-      <caption>E3M3: Sacrificial Bastion</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_p1_8.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>
   <releases>

--- a/dist/io.github.freedoom.Phase1.metainfo.xml
+++ b/dist/io.github.freedoom.Phase1.metainfo.xml
@@ -39,19 +39,19 @@
   </content_rating>
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/tn_p1_1.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_p1_1.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p1_2.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_p1_2.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p1_7.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_p1_7.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p1_8.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_p1_8.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>

--- a/dist/io.github.freedoom.Phase2.metainfo.xml
+++ b/dist/io.github.freedoom.Phase2.metainfo.xml
@@ -38,20 +38,20 @@
   </content_rating>
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/phase2-gzdoom-map05-shotgun-zombies-0.13.0.png</image>
-      <caption>MAP05: Sludge Burrow</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_p2_1.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/phase2-gzdoom-map11-serpentipede-0.13.0.png</image>
-      <caption>MAP11: Whiplash</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_p2_2.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/phase2-gzdoom-map26-mushrooms-0.13.0.png</image>
-      <caption>MAP26: Dark Depths</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_p2_7.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/phase2-gzdoom-map32-matribite-hatchling-0.13.0.png</image>
-      <caption>MAP32: Not Sure</caption>
+      <image>https://freedoom.github.io/img/screenshots/tn_p2_8.png</image>
+      <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>
   <releases>

--- a/dist/io.github.freedoom.Phase2.metainfo.xml
+++ b/dist/io.github.freedoom.Phase2.metainfo.xml
@@ -38,19 +38,19 @@
   </content_rating>
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/tn_p2_1.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_p2_1.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p2_2.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_p2_2.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p2_7.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_p2_7.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p2_8.png</image>
+      <image>https://freedoom.github.io/img/screenshots/tn_p2_8.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
These should now be "forever" URLs linking to image files that can be overwritten with each release without touching these XML files each time.

The current website organizes everything so that we have 8 screenshots of each game, numbered 1-4 for Chocolate and 5-8 for GZ. Including screenshots 1, 2, 7 and 8 therefore should give us a fairly representative variety.

If it's better to link to the full-size screenshots instead, or if different screenshot number should be used for future maintainability, please let me know.