### PR TITLE
credits: remove doubled Mort.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,4 +1,4 @@
-[2023-10-07: This credits file contains entries some of which are now decades old. If you have contributed to Freedoom and want to update anything on here, please post an issue or reach out to any active maintainer!]
+[Some of the entries on this file are decades old. If you have contributed to Freedoom and want to update anything on here, please post an issue or reach out to any active maintainer!]
 
 [See the CREDITS-LEVELS file for specific level authors and titles.]
 [See the CREDITS-MUSIC  file for specific track authors and titles.]
@@ -793,8 +793,8 @@ D: flats, textures
 S: Jared Deberjerak
 D: textures
 
-S: Mortrixs
-D: E3M5
+S: Mortrixs19
+D: levels
 
 S: GooseJelly
 N: Nathaniel Patasky
@@ -879,9 +879,6 @@ D: levels, sounds, sprites, textures, manual
 S: mkrupczak3
 E: matthew@krupczak.org
 D: manual
-
-S: Mortrixs19
-D: levels
 
 N: Nicholas Zatkovich
 S: NickZ


### PR DESCRIPTION
Keeping the 19 in case someone does only a string search for "mortrixs19" and not "mortrixs".

Got rid of the time stamp in the invitation to update info.