### PR TITLE
scripts: For "makepkgs" replace "is" with "=="

### DIFF
--- a/scripts/makepkgs
+++ b/scripts/makepkgs
@@ -24,7 +24,7 @@ version = os.getenv("VERSION")
 if version is None:
     sys.stderr.write("Version not specified for release\n")
     sys.exit(1)
-if version[0] is "v":
+if version[0] == "v":
     # Strip the leading "v" from versioning
     version = version[1:]
 


### PR DESCRIPTION
The "is" keyword is no longer supported, which result in a warning in "make dist" as well as unintentionally having a "v" in the resulting ZIP files and directory within those ZIP files.

---

This solves an 11th hours 0.13.0 mystery I had with my ZIP files looking different than previous ones - "is" support depends on the Python version whereas this  fix does not.

This should be backported to 0.13.1. Should we have a "backport" tag?