### PR TITLE
dist: Use non-thumbnails for screenshots.

### DIFF
--- a/dist/io.github.freedoom.FreeDM.metainfo.xml
+++ b/dist/io.github.freedoom.FreeDM.metainfo.xml
@@ -37,21 +37,23 @@
     <content_attribute id="language-profanity">mild</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
   </content_rating>
+  <!-- Note that some screenshots are PNG and others are JPG. These URLs should
+       not change, but double check them each release. -->
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/tn_dm_1.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/dm_1.png</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_dm_2.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/dm_2.png</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_dm_7.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/dm_7.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_dm_8.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/dm_8.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>

--- a/dist/io.github.freedoom.Phase1.metainfo.xml
+++ b/dist/io.github.freedoom.Phase1.metainfo.xml
@@ -37,21 +37,23 @@
     <content_attribute id="language-profanity">mild</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
   </content_rating>
+  <!-- Note that some screenshots are PNG and others are JPG. These URLs should
+       not change, but double check them each release. -->
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/tn_p1_1.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/p1_1.png</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p1_2.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/p1_2.png</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p1_7.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/p1_7.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p1_8.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/p1_8.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>

--- a/dist/io.github.freedoom.Phase2.metainfo.xml
+++ b/dist/io.github.freedoom.Phase2.metainfo.xml
@@ -36,21 +36,23 @@
     <content_attribute id="language-profanity">mild</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
   </content_rating>
+  <!-- Note that some screenshots are PNG and others are JPG. These URLs should
+       not change, but double check them each release. -->
   <screenshots>
     <screenshot type="default">
-      <image>https://freedoom.github.io/img/screenshots/tn_p2_1.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/p2_1.png</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p2_2.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/p2_2.png</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p2_7.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/p2_7.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
     <screenshot>
-      <image>https://freedoom.github.io/img/screenshots/tn_p2_8.jpg</image>
+      <image>https://freedoom.github.io/img/screenshots/p2_8.jpg</image>
       <caption>Feedoom Screenshot</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
Switch to using the full screenshots in the metainfo files. These URLs should not change.

----

I've checked them, and I've added a comment that should help with the confusion as a result of their being both PNGs and JPGs. My impression is these should be pulled infrequently such as when flatpak and Linux repo packaging is done each Freedoom release, or Linux distro release.