### PR TITLE
lumps: Add UMAPINFO for Phase 1

### DIFF
--- a/buildcfg.txt
+++ b/buildcfg.txt
@@ -154,6 +154,7 @@ FREEDM
 #else
 #ifdef PHASE1
 DEHACKED = p1_deh
+UMAPINFO = p1umpinf
 #else
 DEHACKED = p2_deh
 #endif

--- a/lumps/p1umpinf.lmp
+++ b/lumps/p1umpinf.lmp
@@ -1,0 +1,102 @@
+// UMAPINFO lump for Phase 1. This fixes Episode 4 music playback
+// in non-Crispy/GZDoom ports like Odamex, Eternity and DSDA.
+// Taken from Double Impact MIDI Pack.
+
+MAP E4M1
+{
+       levelname = "Maintenance Area"
+	   levelpic = "WILV30"
+       skytexture = "SKY4"
+	   next = "E4M2"
+	   music = "D_E4M1"
+}
+
+MAP E4M2
+{
+       levelname = "Research Complex"
+	   levelpic = "WILV31"
+       skytexture = "SKY4"
+	   next = "E4M3"
+	   nextsecret = "E4M9"
+	   music = "D_E4M2"
+}
+
+MAP E4M3
+{
+       levelname = "Central Computing"
+	   levelpic = "WILV32"
+       skytexture = "SKY4"
+	   next = "E4M4"
+	   music = "D_E4M3"
+}
+
+MAP E4M4
+{
+       levelname = "Hydroponic Facility"
+	   levelpic = "WILV33"
+       skytexture = "SKY4"
+	   next = "E4M5"
+	   music = "D_E4M4"
+}
+
+MAP E4M5
+{
+       levelname = "Engineering Station"
+	   levelpic = "WILV34"
+       skytexture = "SKY4"
+	   next = "E4M6"
+	   music = "D_E4M5"
+}
+
+MAP E4M6
+{
+       levelname = "Command Center"
+	   levelpic = "WILV35"
+       skytexture = "SKY4"
+	   next = "E4M7"
+	   music = "D_E4M6"
+}
+
+MAP E4M7
+{
+       levelname = "Waste Treatment"
+	   levelpic = "WILV36"
+       skytexture = "SKY4"
+	   next = "E4M8"
+	   music = "D_E4M7"
+}
+
+MAP E4M8
+{
+       levelname = "Launch Bay"
+	   levelpic = "WILV37"
+       skytexture = "SKY4"
+	   music = "D_E4M8"
+	   interbackdrop = "AQF075"
+	   intertext = "Suppressing fire echoes above as the last
+survivors flee the ship. The launch process
+is irreversible: killing you now would only
+bring a slow death drifting through space.
+ 
+Fifty-nine. Fifty-eight. Fifty-seven. .  .
+You melt into the pilot's seat, lost in the
+voice of an automated assembly of angels
+delivering you from this wretched rock.
+ 
+The ship rumbles as she wakes up;
+you think of Earth as she lifts off.
+Hopefully AGM won't find you there:
+they've got the outbreak to deal with,
+so that'll give you some time.
+ 
+Destination: Earth!"
+}
+
+MAP E4M9
+{
+       levelname = "Operations"
+	   levelpic = "WILV38"
+       skytexture = "SKY4"
+	   next = "E4M3"
+	   music = "D_E4M9"
+}

--- a/lumps/p1umpinf.lmp
+++ b/lumps/p1umpinf.lmp
@@ -1,7 +1,9 @@
-// UMAPINFO lump for Phase 1. This fixes Episode 4 music playback
-// in non-Crispy/GZDoom ports like Odamex, Eternity and DSDA.
-// Taken from Double Impact MIDI Pack.
+// UMAPINFO lump for Phase 1.
+// Initially adapted from Double Impact MIDI Pack.
 
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Episode 4 music playback
 MAP E4M1
 {
        levelname = "Maintenance Area"
@@ -9,6 +11,7 @@ MAP E4M1
        skytexture = "SKY4"
 	   next = "E4M2"
 	   music = "D_E4M1"
+	   author = "RottKing and Ralphis"
 }
 
 MAP E4M2
@@ -19,6 +22,7 @@ MAP E4M2
 	   next = "E4M3"
 	   nextsecret = "E4M9"
 	   music = "D_E4M2"
+	   author = "RottKing and Ralphis"
 }
 
 MAP E4M3
@@ -28,6 +32,7 @@ MAP E4M3
        skytexture = "SKY4"
 	   next = "E4M4"
 	   music = "D_E4M3"
+	   author = "RottKing and Ralphis"
 }
 
 MAP E4M4
@@ -37,6 +42,7 @@ MAP E4M4
        skytexture = "SKY4"
 	   next = "E4M5"
 	   music = "D_E4M4"
+	   author = "RottKing and Ralphis"
 }
 
 MAP E4M5
@@ -46,6 +52,7 @@ MAP E4M5
        skytexture = "SKY4"
 	   next = "E4M6"
 	   music = "D_E4M5"
+	   author = "RottKing and Ralphis"
 }
 
 MAP E4M6
@@ -55,6 +62,7 @@ MAP E4M6
        skytexture = "SKY4"
 	   next = "E4M7"
 	   music = "D_E4M6"
+	   author = "RottKing and Ralphis"
 }
 
 MAP E4M7
@@ -64,6 +72,7 @@ MAP E4M7
        skytexture = "SKY4"
 	   next = "E4M8"
 	   music = "D_E4M7"
+	   author = "RottKing and Ralphis"
 }
 
 MAP E4M8
@@ -73,6 +82,7 @@ MAP E4M8
        skytexture = "SKY4"
 	   music = "D_E4M8"
 	   interbackdrop = "AQF075"
+	   author = "RottKing and Ralphis"
 	   intertext = "Suppressing fire echoes above as the last
 survivors flee the ship. The launch process
 is irreversible: killing you now would only
@@ -99,4 +109,5 @@ MAP E4M9
        skytexture = "SKY4"
 	   next = "E4M3"
 	   music = "D_E4M9"
+	   author = "RottKing and Ralphis"
 }


### PR DESCRIPTION
This fixes Episode 4 music playback in non-Crispy/GZDoom ports like Odamex, Eternity and DSDADoom. Taken from Double Impact MIDI Pack and tweaked for parity with DeHackEd.