### PR TITLE
README: Remove outdated paragraph

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -154,9 +154,6 @@ It is sensible to also heed the following guidelines:
     engines, especially those that use hardware accelerated rendering,
     may not render it properly.  Examples of tricks to avoid include
     those used to simulate 3D bridges and “deep water” effects.
-  * While unrestricted by limits, do not make excessively complicated
-    scenes.  It is desirable that _Freedoom_ levels should be playable
-    on low-powered hardware, such as phones and old computers.
   * Test your levels in https://www.chocolate-doom.org/[Chocolate
     Doom] to make sure that vanilla compatibility is maintained.  This
     is an engine with strict adherence to vanilla Doom limits and


### PR DESCRIPTION
This is left over from before the change to vanilla as the target for levels. The change should inherently ensure that scenes will never be too complicated.