### PR TITLE
CI: Bump to upload-artifact v4.

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -44,12 +44,12 @@ jobs:
         fi
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Upload Freedoom
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         path: "artifacts/freedoom"
         name: freedoom-${{steps.buildstep.outputs.VERSION}}
     - name: Upload Freedm
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         path: "artifacts/freedm"
         name: freedm-${{steps.buildstep.outputs.VERSION}}


### PR DESCRIPTION
Version 1 is deprecated and now fails when run:

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/