### PR TITLE
lumps: Add GAMECONF, WADINFO, UMAPINFO

### DIFF
--- a/buildcfg.txt
+++ b/buildcfg.txt
@@ -148,14 +148,23 @@ DBIGFONT
 
 #ifdef FREEDM
 DEHACKED = fdm_deh
+UMAPINFO = fdmuminf
+GAMECONF = fdmgconf
+WADINFO = fdmwdinf
 ZMAPINFO = fdmmpinf
 ENDOOM = endoomdm
 FREEDM
 #else
 #ifdef PHASE1
 DEHACKED = p1_deh
+UMAPINFO = p1_uminf
+GAMECONF = p1_gconf
+WADINFO = p1_wdinf
 #else
 DEHACKED = p2_deh
+UMAPINFO = p2_uminf
+GAMECONF = p2_gconf
+WADINFO = p2_wdinf
 #endif
 ENDOOM
 #endif

--- a/lumps/fdmgconf.lmp
+++ b/lumps/fdmgconf.lmp
@@ -1,0 +1,18 @@
+{
+  "type": "gameconf",
+  "version": "1.0.0",
+  "metadata": { },
+  "data":
+  {
+    "title": "FreeDM",
+    "author": "The Freedoom Project",
+    "description": "The Freedoom project aims to create a complete, free content first person shooter game.",
+    "version": "0.13.0",
+    "iwad": null,
+    "pwadfiles": null,
+    "dehfiles": null,
+    "executable": "doom1.9",
+    "mode": "commercial",
+    "options": null
+  }
+}

--- a/lumps/fdmuminf.lmp
+++ b/lumps/fdmuminf.lmp
@@ -1,0 +1,299 @@
+// UMAPINFO lump for FreeDM.
+
+// SPDX-License-Identifier: BSD-3-Clause
+
+map MAP01
+{
+	levelpic = "CWILV00"
+	levelname = "Tech Test"
+	next = "MAP02"
+	skytexture = "SKY1"
+	music = "D_RUNNIN"
+}
+
+map MAP02
+{
+	levelpic = "CWILV01"
+	levelname = "Natural Station"
+	next = "MAP03"
+	skytexture = "SKY1"
+	music = "D_STALKS"
+}
+
+map MAP03
+{
+	levelpic = "CWILV02"
+	levelname = "Issues of Claveria"
+	next = "MAP04"
+	skytexture = "SKY1"
+	music = "D_COUNTD"
+}
+
+map MAP04
+{
+	levelpic = "CWILV03"
+	levelname = "Steel"
+	next = "MAP05"
+	skytexture = "SKY1"
+	music = "D_BETWEE"
+}
+
+map MAP05
+{
+	levelpic = "CWILV04"
+	levelname = "Dense Fields"
+	next = "MAP06"
+	skytexture = "SKY1"
+	music = "D_DOOM"
+}
+
+map MAP06
+{
+	levelpic = "CWILV05"
+	levelname = "Temple of Ammon"
+	next = "MAP07"
+	skytexture = "SKY1"
+	music = "D_THE_DA"
+	intertext = clear
+}
+
+map MAP07
+{
+	levelpic = "CWILV06"
+	levelname = "Main Stronghold"
+	next = "MAP08"
+	skytexture = "SKY1"
+	music = "D_SHAWN"
+}
+
+map MAP08
+{
+	levelpic = "CWILV07"
+	levelname = "Artifact Base"
+	next = "MAP09"
+	skytexture = "SKY1"
+	music = "D_DDTBLU"
+}
+
+map MAP09
+{
+	levelpic = "CWILV08"
+	levelname = "Industrial Outland"
+	next = "MAP10"
+	skytexture = "SKY1"
+	music = "D_IN_CIT"
+}
+
+map MAP10
+{
+	levelpic = "CWILV09"
+	levelname = "Detached Grounds"
+	next = "MAP11"
+	skytexture = "SKY1"
+	music = "D_DEAD"
+}
+
+map MAP11
+{
+	levelpic = "CWILV10"
+	levelname = "Isolated Facility"
+	next = "MAP12"
+	skytexture = "SKY1"
+	music = "D_STLKS2"
+	intertext = clear
+}
+
+map MAP12
+{
+	levelpic = "CWILV11"
+	levelname = "Up 'n' Down Canyon"
+	next = "MAP13"
+	skytexture = "SKY2"
+	music = "D_THEDA2"
+}
+
+map MAP13
+{
+	levelpic = "CWILV12"
+	levelname = "Unholy Blood"
+	next = "MAP14"
+	skytexture = "SKY2"
+	music = "D_DOOM2"
+}
+
+map MAP14
+{
+	levelpic = "CWILV13"
+	levelname = "Technical Assault"
+	next = "MAP15"
+	skytexture = "SKY2"
+	music = "D_DDTBL2"
+}
+
+map MAP15
+{
+	levelpic = "CWILV14"
+	levelname = "Shallow Complex"
+	next = "MAP16"
+	nextsecret = "MAP31"
+	skytexture = "SKY2"
+	music = "D_RUNNI2"
+	intertextsecret = clear
+}
+
+map MAP16
+{
+	levelpic = "CWILV15"
+	levelname = "Barren Alleys"
+	next = "MAP17"
+	skytexture = "SKY2"
+	music = "D_DEAD2"
+}
+
+map MAP17
+{
+	levelpic = "CWILV16"
+	levelname = "Underwoods"
+	next = "MAP18"
+	skytexture = "SKY2"
+	music = "D_STLKS3"
+}
+
+map MAP18
+{
+	levelpic = "CWILV17"
+	levelname = "Deserted Courtyard"
+	next = "MAP19"
+	skytexture = "SKY2"
+	music = "D_ROMERO"
+}
+
+map MAP19
+{
+	levelpic = "CWILV18"
+	levelname = "Tech Isle"
+	next = "MAP20"
+	skytexture = "SKY2"
+	music = "D_SHAWN2"
+}
+
+map MAP20
+{
+	levelpic = "CWILV19"
+	levelname = "Warehouse"
+	next = "MAP21"
+	skytexture = "SKY2"
+	music = "D_MESSAG"
+	intertext = clear
+}
+
+map MAP21
+{
+	levelpic = "CWILV20"
+	levelname = "Refinery"
+	next = "MAP22"
+	skytexture = "SKY3"
+	music = "D_COUNT2"
+}
+
+map MAP22
+{
+	levelpic = "CWILV21"
+	levelname = "Military Depot"
+	next = "MAP23"
+	skytexture = "SKY3"
+	music = "D_DDTBL3"
+}
+
+map MAP23
+{
+	levelpic = "CWILV22"
+	levelname = "Confrontation"
+	next = "MAP24"
+	skytexture = "SKY3"
+	music = "D_AMPIE"
+}
+
+map MAP24
+{
+	levelpic = "CWILV23"
+	levelname = "Flooded Base"
+	next = "MAP25"
+	skytexture = "SKY3"
+	music = "D_THEDA3"
+}
+
+map MAP25
+{
+	levelpic = "CWILV24"
+	levelname = "Mansion Yard"
+	next = "MAP26"
+	skytexture = "SKY3"
+	music = "D_ADRIAN"
+}
+
+map MAP26
+{
+	levelpic = "CWILV25"
+	levelname = "Acidic Crypt"
+	next = "MAP27"
+	skytexture = "SKY3"
+	music = "D_MESSG2"
+}
+
+map MAP27
+{
+	levelpic = "CWILV26"
+	levelname = "The Exile"
+	next = "MAP28"
+	skytexture = "SKY3"
+	music = "D_ROMER2"
+}
+
+map MAP28
+{
+	levelpic = "CWILV27"
+	levelname = "Weapons Factory"
+	next = "MAP29"
+	skytexture = "SKY3"
+	music = "D_TENSE"
+}
+
+map MAP29
+{
+	levelpic = "CWILV28"
+	levelname = "Unusual Territory"
+	next = "MAP30"
+	skytexture = "SKY3"
+	music = "D_SHAWN3"
+}
+
+map MAP30
+{
+	levelpic = "CWILV29"
+	levelname = "Last Man Standing"
+	next = "MAP01"
+	skytexture = "SKY3"
+	music = "D_OPENIN"
+	intertext = clear
+}
+
+map MAP31
+{
+	levelpic = "CWILV30"
+	levelname = "Desolated Fort"
+	next = "MAP16"
+	nextsecret = "MAP32"
+	skytexture = "SKY2"
+	music = "D_EVIL"
+	intertextsecret = clear
+}
+
+map MAP32
+{
+	levelpic = "CWILV31"
+	levelname = "Fourplay"
+	next = "MAP16"
+	skytexture = "SKY2"
+	music = "D_ULTIMA"
+}

--- a/lumps/fdmwdinf.lmp
+++ b/lumps/fdmwdinf.lmp
@@ -1,0 +1,92 @@
+===========================================================================
+Advanced engine needed  : Vanilla-compatible
+Primary purpose         : Deathmatch
+===========================================================================
+Title                   : FreeDM
+Filename                : freedm.wad
+Release date            : 2024-01-29
+Author                  : The Freedoom Project
+Version                 : 0.13.0
+Other Files By Author   : Freedoom: Phase 1, Freedoom: Phase 2
+Misc. Author Info       : Contributors to the Freedoom Project
+
+Description             : The Freedoom project aims to provide all the
+                          content needed to form a complete, entirely
+                          free/libre game for the Doom engine. It is designed
+                          to be compatible with most custom levels, music,
+                          graphics and other modifications (mods) made for
+                          the original Doom games by Doom fans and artists
+                          over the decades.
+
+Additional Credits to   : See the CREDITS file
+===========================================================================
+* What is included *
+
+New levels              : 32
+Sounds                  : Yes
+Music                   : Yes
+Graphics                : Yes
+Dehacked/BEX Patch      : Yes
+Demos                   : Yes
+Other                   : No
+Other files required    : None
+
+
+* Play Information *
+
+Game                    : Doom 2
+Single Player           : Designed for
+Cooperative 2-4 Player  : Designed for
+Deathmatch 2-4 Player   : Designed for
+Other game styles       : None
+Difficulty Settings     : Not implemented
+
+
+* Construction *
+
+Base                    : New from scratch
+Build Time              : Since 2001
+Editor(s) used          : DeuTex
+Known Bugs              : Please report bugs to
+                          https://github.com/freedoom/freedoom/issues
+May Not Run With        : None
+Tested With             : Chocolate Doom, Crispy Doom, Odamex, GZDoom
+
+
+* Copyright / Permissions *
+
+Copyright © 2001-2024
+Contributors to the Freedoom project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the Freedoom project nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS
+IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For a list of contributors to the Freedoom project, see the file
+CREDITS.
+
+* Where to get the file that this text file describes *
+
+The Usual: ftp://archives.gamers.org/pub/idgames/ and mirrors
+Web sites: https://freedoom.github.io/

--- a/lumps/p1_gconf.lmp
+++ b/lumps/p1_gconf.lmp
@@ -1,0 +1,18 @@
+{
+  "type": "gameconf",
+  "version": "1.0.0",
+  "metadata": { },
+  "data":
+  {
+    "title": "Freedoom: Phase 1",
+    "author": "The Freedoom Project",
+    "description": "The Freedoom project aims to create a complete, free content first person shooter game.",
+    "version": "0.13.0",
+    "iwad": null,
+    "pwadfiles": null,
+    "dehfiles": null,
+    "executable": "doom1.9",
+    "mode": "retail",
+    "options": null
+  }
+}

--- a/lumps/p1_uminf.lmp
+++ b/lumps/p1_uminf.lmp
@@ -1,0 +1,113 @@
+// UMAPINFO lump for Phase 1.
+// Initially adapted from Double Impact MIDI Pack.
+
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Episode 4 music playback
+MAP E4M1
+{
+       levelname = "Maintenance Area"
+	   levelpic = "WILV30"
+       skytexture = "SKY4"
+	   next = "E4M2"
+	   music = "D_E4M1"
+	   author = "RottKing and Ralphis"
+}
+
+MAP E4M2
+{
+       levelname = "Research Complex"
+	   levelpic = "WILV31"
+       skytexture = "SKY4"
+	   next = "E4M3"
+	   nextsecret = "E4M9"
+	   music = "D_E4M2"
+	   author = "RottKing and Ralphis"
+}
+
+MAP E4M3
+{
+       levelname = "Central Computing"
+	   levelpic = "WILV32"
+       skytexture = "SKY4"
+	   next = "E4M4"
+	   music = "D_E4M3"
+	   author = "RottKing and Ralphis"
+}
+
+MAP E4M4
+{
+       levelname = "Hydroponic Facility"
+	   levelpic = "WILV33"
+       skytexture = "SKY4"
+	   next = "E4M5"
+	   music = "D_E4M4"
+	   author = "RottKing and Ralphis"
+}
+
+MAP E4M5
+{
+       levelname = "Engineering Station"
+	   levelpic = "WILV34"
+       skytexture = "SKY4"
+	   next = "E4M6"
+	   music = "D_E4M5"
+	   author = "RottKing and Ralphis"
+}
+
+MAP E4M6
+{
+       levelname = "Command Center"
+	   levelpic = "WILV35"
+       skytexture = "SKY4"
+	   next = "E4M7"
+	   music = "D_E4M6"
+	   author = "RottKing and Ralphis"
+}
+
+MAP E4M7
+{
+       levelname = "Waste Treatment"
+	   levelpic = "WILV36"
+       skytexture = "SKY4"
+	   next = "E4M8"
+	   music = "D_E4M7"
+	   author = "RottKing and Ralphis"
+}
+
+MAP E4M8
+{
+       levelname = "Launch Bay"
+	   levelpic = "WILV37"
+       skytexture = "SKY4"
+	   music = "D_E4M8"
+	   interbackdrop = "AQF075"
+	   author = "RottKing and Ralphis"
+	   intertext = "Suppressing fire echoes above as the last
+survivors flee the ship. The launch process
+is irreversible: killing you now would only
+bring a slow death drifting through space.
+ 
+Fifty-nine. Fifty-eight. Fifty-seven. .  .
+You melt into the pilot's seat, lost in the
+voice of an automated assembly of angels
+delivering you from this wretched rock.
+ 
+The ship rumbles as she wakes up;
+you think of Earth as she lifts off.
+Hopefully AGM won't find you there:
+they've got the outbreak to deal with,
+so that'll give you some time.
+ 
+Destination: Earth!"
+}
+
+MAP E4M9
+{
+       levelname = "Operations"
+	   levelpic = "WILV38"
+       skytexture = "SKY4"
+	   next = "E4M3"
+	   music = "D_E4M9"
+	   author = "RottKing and Ralphis"
+}

--- a/lumps/p1_wdinf.lmp
+++ b/lumps/p1_wdinf.lmp
@@ -1,0 +1,92 @@
+===========================================================================
+Advanced engine needed  : Vanilla-compatible
+Primary purpose         : Single + coop play
+===========================================================================
+Title                   : Freedoom: Phase 1
+Filename                : freedoom1.wad
+Release date            : 2024-01-29
+Author                  : The Freedoom Project
+Version                 : 0.13.0
+Other Files By Author   : Freedoom: Phase 2, FreeDM
+Misc. Author Info       : Contributors to the Freedoom Project
+
+Description             : The Freedoom project aims to provide all the
+                          content needed to form a complete, entirely
+                          free/libre game for the Doom engine. It is designed
+                          to be compatible with most custom levels, music,
+                          graphics and other modifications (mods) made for
+                          the original Doom games by Doom fans and artists
+                          over the decades.
+
+Additional Credits to   : See the CREDITS file
+===========================================================================
+* What is included *
+
+New levels              : 36
+Sounds                  : Yes
+Music                   : Yes
+Graphics                : Yes
+Dehacked/BEX Patch      : Yes
+Demos                   : Yes
+Other                   : No
+Other files required    : None
+
+
+* Play Information *
+
+Game                    : Doom
+Single Player           : Designed for
+Cooperative 2-4 Player  : Designed for
+Deathmatch 2-4 Player   : Designed for
+Other game styles       : None
+Difficulty Settings     : Not implemented
+
+
+* Construction *
+
+Base                    : New from scratch
+Build Time              : Since 2001
+Editor(s) used          : DeuTex
+Known Bugs              : Please report bugs to
+                          https://github.com/freedoom/freedoom/issues
+May Not Run With        : None
+Tested With             : Chocolate Doom, Crispy Doom, Odamex, GZDoom
+
+
+* Copyright / Permissions *
+
+Copyright © 2001-2024
+Contributors to the Freedoom project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the Freedoom project nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS
+IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For a list of contributors to the Freedoom project, see the file
+CREDITS.
+
+* Where to get the file that this text file describes *
+
+The Usual: ftp://archives.gamers.org/pub/idgames/ and mirrors
+Web sites: https://freedoom.github.io/

--- a/lumps/p2_gconf.lmp
+++ b/lumps/p2_gconf.lmp
@@ -1,0 +1,18 @@
+{
+  "type": "gameconf",
+  "version": "1.0.0",
+  "metadata": { },
+  "data":
+  {
+    "title": "Freedoom: Phase 2",
+    "author": "The Freedoom Project",
+    "description": "The Freedoom project aims to create a complete, free content first person shooter game.",
+    "version": "0.13.0",
+    "iwad": null,
+    "pwadfiles": null,
+    "dehfiles": null,
+    "executable": "doom1.9",
+    "mode": "commercial",
+    "options": null
+  }
+}

--- a/lumps/p2_uminf.lmp
+++ b/lumps/p2_uminf.lmp
@@ -1,4 +1,4 @@
-// UMAPINFO lump for FreeDM.
+// UMAPINFO lump for Phase 2.
 
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/lumps/p2_uminf.lmp
+++ b/lumps/p2_uminf.lmp
@@ -1,0 +1,398 @@
+// UMAPINFO lump for FreeDM.
+
+// SPDX-License-Identifier: BSD-3-Clause
+
+map MAP01
+{
+	levelpic = "CWILV00"
+	levelname = "Hydroelectric Plant"
+	next = "MAP02"
+	skytexture = "SKY1"
+	music = "D_RUNNIN"
+}
+
+map MAP02
+{
+	levelpic = "CWILV01"
+	levelname = "Filtration Tunnels"
+	next = "MAP03"
+	skytexture = "SKY1"
+	music = "D_STALKS"
+}
+
+map MAP03
+{
+	levelpic = "CWILV02"
+	levelname = "Crude Processing Center"
+	next = "MAP04"
+	skytexture = "SKY1"
+	music = "D_COUNTD"
+}
+
+map MAP04
+{
+	levelpic = "CWILV03"
+	levelname = "Containment Bay"
+	next = "MAP05"
+	skytexture = "SKY1"
+	music = "D_BETWEE"
+}
+
+map MAP05
+{
+	levelpic = "CWILV04"
+	levelname = "Sludge Burrow"
+	next = "MAP06"
+	skytexture = "SKY1"
+	music = "D_DOOM"
+}
+
+map MAP06
+{
+	levelpic = "CWILV05"
+	levelname = "Janus Terminal"
+	next = "MAP07"
+	skytexture = "SKY1"
+	music = "D_THE_DA"
+	interbackdrop = "AQF016"
+	intertext = "Not even Earth is safe. The monsters show
+up ahead of you everywhere you run.
+Where are they even coming from?
+         
+Despite all the other destruction they've
+wrought, the teleportation infrastructure
+remains intact - you might be able to
+get back to civilization this way.
+         
+You find an old pad and boot it up.
+Connection live. Handshake established.
+         
+Growling and chittering on the intercom.
+         
+Planted your feet.
+Checked your weapons.
+Time to punch through."
+}
+
+map MAP07
+{
+	levelpic = "CWILV06"
+	levelname = "Logic Gate"
+	next = "MAP08"
+	skytexture = "SKY1"
+	music = "D_SHAWN"
+}
+
+map MAP08
+{
+	levelpic = "CWILV07"
+	levelname = "Astronomy Complex"
+	next = "MAP09"
+	skytexture = "SKY1"
+	music = "D_DDTBLU"
+}
+
+map MAP09
+{
+	levelpic = "CWILV08"
+	levelname = "Datacenter"
+	next = "MAP10"
+	skytexture = "SKY1"
+	music = "D_IN_CIT"
+}
+
+map MAP10
+{
+	levelpic = "CWILV09"
+	levelname = "Deadly Outlands"
+	next = "MAP11"
+	skytexture = "SKY1"
+	music = "D_DEAD"
+}
+
+map MAP11
+{
+	levelpic = "CWILV10"
+	levelname = "Dimensional Rift Observatory"
+	next = "MAP12"
+	skytexture = "SKY1"
+	music = "D_STLKS2"
+	interbackdrop = "AQF001"
+	intertext = "You didn't find anyone alive. Again.
+
+The fighting is taking its toll on you.
+The pain. The brutality. The loneliness.
+There's got to be a way to somewhere,
+something that isn't... this.
+
+A train rumbles in the distance.
+
+You follow the sound down the empty road
+and reach the edge of a railyard.
+
+Trains mean cities.
+Cities mean people.
+
+Right?"
+}
+
+map MAP12
+{
+	levelpic = "CWILV11"
+	levelname = "Railroads"
+	next = "MAP13"
+	skytexture = "SKY2"
+	music = "D_THEDA2"
+}
+
+map MAP13
+{
+	levelpic = "CWILV12"
+	levelname = "Station Earth"
+	next = "MAP14"
+	skytexture = "SKY2"
+	music = "D_DOOM2"
+}
+
+map MAP14
+{
+	levelpic = "CWILV13"
+	levelname = "Nuclear Zone"
+	next = "MAP15"
+	skytexture = "SKY2"
+	music = "D_DDTBL2"
+}
+
+map MAP15
+{
+	levelpic = "CWILV14"
+	levelname = "Hostile Takeover"
+	next = "MAP16"
+	nextsecret = "MAP31"
+	skytexture = "SKY2"
+	music = "D_RUNNI2"
+	interbackdrop = "AQF004"
+	intertextsecret = "You step into the teleporter. You feel a
+familiar flash and... you're in a cage?
+Jailed?
+
+There are other cages in here. Occupied.
+So is this how they capture humans?
+Or did they set this up specially for you,
+as a reward for being such a monkey wrench
+in their plans?
+
+The guards haven't noticed you - yet.
+Any noise could mean death. Or worse.
+
+When they zombify you, are you awake the
+entire time, locked inside of your brain?
+
+You'd rather not find out."
+}
+
+map MAP16
+{
+	levelpic = "CWILV15"
+	levelname = "Urban Jungle"
+	next = "MAP17"
+	skytexture = "SKY2"
+	music = "D_DEAD2"
+}
+
+map MAP17
+{
+	levelpic = "CWILV16"
+	levelname = "City Capitol"
+	next = "MAP18"
+	skytexture = "SKY2"
+	music = "D_STLKS3"
+}
+
+map MAP18
+{
+	levelpic = "CWILV17"
+	levelname = "Aquatics Lab"
+	next = "MAP19"
+	skytexture = "SKY2"
+	music = "D_ROMERO"
+}
+
+map MAP19
+{
+	levelpic = "CWILV18"
+	levelname = "Sewage Control"
+	next = "MAP20"
+	skytexture = "SKY2"
+	music = "D_SHAWN2"
+}
+
+map MAP20
+{
+	levelpic = "CWILV19"
+	levelname = "Blood Ember Fortress"
+	next = "MAP21"
+	skytexture = "SKY2"
+	music = "D_MESSAG"
+	interbackdrop = "FLAT5_6"
+	intertext = "Here is no AGM but only monsters.
+Monsters, no humans and dusty days
+sleeping in old ruins and eating scraps.
+No one has escaped this wasteland alive.
+
+You've been tracking their movements.
+AGM records and alien scrawlings point
+to something big worming its way through
+the entire teleportation network.
+Sending its nightmare armies of brain-
+scrambled sapients - including humans -
+to conquer all known space.
+
+And now you're fighting at its doorstep.
+
+This could be the beginning
+of your freedom - or your doom."
+}
+
+map MAP21
+{
+	levelpic = "CWILV20"
+	levelname = "Under Realm"
+	next = "MAP22"
+	skytexture = "SKY3"
+	music = "D_COUNT2"
+}
+
+map MAP22
+{
+	levelpic = "CWILV21"
+	levelname = "Remanasu"
+	next = "MAP23"
+	skytexture = "SKY3"
+	music = "D_DDTBL3"
+}
+
+map MAP23
+{
+	levelpic = "CWILV22"
+	levelname = "Underground Facility"
+	next = "MAP24"
+	skytexture = "SKY3"
+	music = "D_AMPIE"
+}
+
+map MAP24
+{
+	levelpic = "CWILV23"
+	levelname = "Abandoned Teleporter Lab"
+	next = "MAP25"
+	skytexture = "SKY3"
+	music = "D_THEDA3"
+}
+
+map MAP25
+{
+	levelpic = "CWILV24"
+	levelname = "Persistence of Memory"
+	next = "MAP26"
+	skytexture = "SKY3"
+	music = "D_ADRIAN"
+}
+
+map MAP26
+{
+	levelpic = "CWILV25"
+	levelname = "Dark Depths"
+	next = "MAP27"
+	skytexture = "SKY3"
+	music = "D_MESSG2"
+}
+
+map MAP27
+{
+	levelpic = "CWILV26"
+	levelname = "Palace of Red"
+	next = "MAP28"
+	skytexture = "SKY3"
+	music = "D_ROMER2"
+}
+
+map MAP28
+{
+	levelpic = "CWILV27"
+	levelname = "Grim Redoubt"
+	next = "MAP29"
+	skytexture = "SKY3"
+	music = "D_TENSE"
+}
+
+map MAP29
+{
+	levelpic = "CWILV28"
+	levelname = "Melting Point"
+	next = "MAP30"
+	skytexture = "SKY3"
+	music = "D_SHAWN3"
+}
+
+map MAP30
+{
+	levelpic = "CWILV29"
+	levelname = "Jaws of Defeat"
+	skytexture = "SKY3"
+	endcast = true
+	music = "D_OPENIN"
+	interbackdrop = "SLIME13"
+	intertext = "The evil thing becomes unstable.
+Its final roars echo throughout the room
+until it crumples into scrap metal.
+
+A targeting portal opens, blissfully
+unaware of its master's demise.
+
+On the other side you see a small town.
+You ditch your weapons and slip through,
+leaving AGM and all its horrors behind.
+
+No one will know who saved them.
+
+No one will know what happened here.
+
+No one will ever find you again."
+}
+
+map MAP31
+{
+	levelpic = "CWILV30"
+	levelname = "Be Quiet"
+	next = "MAP16"
+	nextsecret = "MAP32"
+	skytexture = "SKY2"
+	music = "D_EVIL"
+	interbackdrop = "AQF021"
+	intertextsecret = "Forcibly uncaged again. Good job.
+
+But where are you? The air and gravity
+still feel like whatever planet that
+strange prison had been on.
+
+You look around and the layout triggers
+some old memories from history class.
+
+This is an arena.
+Where they send prisoners to die.
+That wasn't an exit - but an entrance.
+
+You will find your way back to the city,
+but it will have to be on the other side
+of a few homicidal mutants..."
+}
+
+map MAP32
+{
+	levelpic = "CWILV31"
+	levelname = "Not Sure"
+	next = "MAP16"
+	skytexture = "SKY2"
+	music = "D_ULTIMA"
+}

--- a/lumps/p2_wdinf.lmp
+++ b/lumps/p2_wdinf.lmp
@@ -1,0 +1,92 @@
+===========================================================================
+Advanced engine needed  : Vanilla-compatible
+Primary purpose         : Single + coop play
+===========================================================================
+Title                   : Freedoom: Phase 2
+Filename                : freedoom2.wad
+Release date            : 2024-01-29
+Author                  : The Freedoom Project
+Version                 : 0.13.0
+Other Files By Author   : Freedoom: Phase 1, FreeDM
+Misc. Author Info       : Contributors to the Freedoom Project
+
+Description             : The Freedoom project aims to provide all the
+                          content needed to form a complete, entirely
+                          free/libre game for the Doom engine. It is designed
+                          to be compatible with most custom levels, music,
+                          graphics and other modifications (mods) made for
+                          the original Doom games by Doom fans and artists
+                          over the decades.
+
+Additional Credits to   : See the CREDITS file
+===========================================================================
+* What is included *
+
+New levels              : 32
+Sounds                  : Yes
+Music                   : Yes
+Graphics                : Yes
+Dehacked/BEX Patch      : Yes
+Demos                   : Yes
+Other                   : No
+Other files required    : None
+
+
+* Play Information *
+
+Game                    : Doom 2
+Single Player           : Designed for
+Cooperative 2-4 Player  : Designed for
+Deathmatch 2-4 Player   : Designed for
+Other game styles       : None
+Difficulty Settings     : Not implemented
+
+
+* Construction *
+
+Base                    : New from scratch
+Build Time              : Since 2001
+Editor(s) used          : DeuTex
+Known Bugs              : Please report bugs to
+                          https://github.com/freedoom/freedoom/issues
+May Not Run With        : None
+Tested With             : Chocolate Doom, Crispy Doom, Odamex, GZDoom
+
+
+* Copyright / Permissions *
+
+Copyright © 2001-2024
+Contributors to the Freedoom project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the Freedoom project nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS
+IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For a list of contributors to the Freedoom project, see the file
+CREDITS.
+
+* Where to get the file that this text file describes *
+
+The Usual: ftp://archives.gamers.org/pub/idgames/ and mirrors
+Web sites: https://freedoom.github.io/


### PR DESCRIPTION
Fixes #1439. I hope I did things right.
Phase 2 UMAPINFO is based on an example from [that Doomworld post](https://www.doomworld.com/forum/topic/147219-nightdives-doom-curated-community-list-of-classic-doom-mods/).
FreeDM UMAPINFO removes the intermission text and loops the level order as in the current ZMAPINFO
UMAPINFO for Phase 1 only includes maps from Double Impact and allows tracks from the MIDI Pack to be played. 
WADINFOs are created using the idgames generator