### PR TITLE
CI: use deutex and ruby-asciidoctor-pdf from Ubuntu repositories

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -18,18 +18,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         sudo apt update
-        sudo apt install python3-pil asciidoc unzip zip ruby dos2unix
-        sudo gem install asciidoctor-pdf --pre
-    - name: Install Deutex
-      run: |
-        git clone https://github.com/Doom-Utils/deutex.git
-        cd deutex
-        git checkout v5.2.1
-        sudo apt install libpng-dev
-        ./bootstrap
-        ./configure
-        make
-        sudo make install
+        sudo apt install deutex python3-pil asciidoc unzip zip ruby-asciidoctor-pdf dos2unix
     - name: Build
       id: buildstep
       run: |


### PR DESCRIPTION
Currently, ubuntu-latest is at Ubuntu 24.04.
Deutex 5.x and ruby-asciidoctor-pdf are in Ubuntu since at least 20.04.