### PR TITLE
Add authors to umapinfo lumps

### DIFF
--- a/lumps/fdmuminf.lmp
+++ b/lumps/fdmuminf.lmp
@@ -13,6 +13,7 @@ map MAP01
 	ParTime = 0
 	Episode = clear
 	Episode = "M_EPI1", "FreeDM", "1"
+	Author = "Xindage"
 }
 
 map MAP02
@@ -24,6 +25,7 @@ map MAP02
 	Music = "D_STALKS"
 	SkyTexture = "SKY1"
 	ParTime = 0
+	Author = "Hellbent"
 }
 
 map MAP03
@@ -35,6 +37,7 @@ map MAP03
 	Music = "D_COUNTD"
 	SkyTexture = "SKY1"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP04
@@ -46,6 +49,7 @@ map MAP04
 	Music = "D_BETWEE"
 	SkyTexture = "SKY1"
 	ParTime = 0
+	Author = "deathz0r"
 }
 
 map MAP05
@@ -57,6 +61,7 @@ map MAP05
 	Music = "D_DOOM"
 	SkyTexture = "SKY1"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP06
@@ -69,6 +74,7 @@ map MAP06
 	SkyTexture = "SKY1"
 	InterText = clear
 	ParTime = 0
+	Author = "Catoptromancy& Xindage"
 }
 
 map MAP07
@@ -80,6 +86,7 @@ map MAP07
 	Music = "D_SHAWN"
 	SkyTexture = "SKY1"
 	ParTime = 0
+	Author = "Rellik"
 }
 
 map MAP08
@@ -91,6 +98,7 @@ map MAP08
 	Music = "D_DDTBLU"
 	SkyTexture = "SKY1"
 	ParTime = 0
+	Author = "AXDOOMER"
 }
 
 map MAP09
@@ -102,6 +110,7 @@ map MAP09
 	Music = "D_IN_CIT"
 	SkyTexture = "SKY1"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP10
@@ -113,6 +122,7 @@ map MAP10
 	Music = "D_DEAD"
 	SkyTexture = "SKY1"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP11
@@ -124,6 +134,7 @@ map MAP11
 	Music = "D_STLKS2"
 	SkyTexture = "SKY1"
 	InterText = clear
+	Author = "Xindage"
 }
 
 map MAP12
@@ -135,6 +146,7 @@ map MAP12
 	Music = "D_THEDA2"
 	SkyTexture = "SKY2"
 	ParTime = 0
+	Author = "Catoptromancy"
 }
 
 map MAP13
@@ -146,6 +158,7 @@ map MAP13
 	Music = "D_DOOM2"
 	SkyTexture = "SKY2"
 	ParTime = 0
+	Author = "Catoptromancy & Xindage"
 }
 
 map MAP14
@@ -157,6 +170,7 @@ map MAP14
 	Music = "D_DDTBL2"
 	SkyTexture = "SKY2"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP15
@@ -169,6 +183,7 @@ map MAP15
 	Music = "D_RUNNI2"
 	SkyTexture = "SKY2"
 	InterTextSecret = clear
+	Author = "Xindage"
 }
 
 map MAP16
@@ -180,6 +195,7 @@ map MAP16
 	Music = "D_DEAD2"
 	SkyTexture = "SKY2"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP17
@@ -191,6 +207,7 @@ map MAP17
 	Music = "D_STLKS3"
 	SkyTexture = "SKY2"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP18
@@ -202,6 +219,7 @@ map MAP18
 	Music = "D_ROMERO"
 	SkyTexture = "SKY2"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP19
@@ -213,6 +231,7 @@ map MAP19
 	Music = "D_SHAWN2"
 	SkyTexture = "SKY2"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP20
@@ -224,6 +243,7 @@ map MAP20
 	Music = "D_MESSAG"
 	SkyTexture = "SKY2"
 	InterText = clear
+	Author = "Xindage"
 }
 
 map MAP21
@@ -235,6 +255,7 @@ map MAP21
 	Music = "D_COUNT2"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Rellik"
 }
 
 map MAP22
@@ -246,6 +267,7 @@ map MAP22
 	Music = "D_DDTBL3"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "AXDOOMER"
 }
 
 map MAP23
@@ -257,6 +279,7 @@ map MAP23
 	Music = "D_AMPIE"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP24
@@ -268,6 +291,7 @@ map MAP24
 	Music = "D_THEDA3"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Mechadon"
 }
 
 map MAP25
@@ -279,6 +303,7 @@ map MAP25
 	Music = "D_ADRIAN"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Catoptromancy"
 }
 
 map MAP26
@@ -290,6 +315,7 @@ map MAP26
 	Music = "D_MESSG2"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP27
@@ -301,6 +327,7 @@ map MAP27
 	Music = "D_ROMER2"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Rellik"
 }
 
 map MAP28
@@ -312,6 +339,7 @@ map MAP28
 	Music = "D_TENSE"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Rellik"
 }
 
 map MAP29
@@ -323,6 +351,7 @@ map MAP29
 	Music = "D_SHAWN3"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Xindage"
 }
 
 map MAP30
@@ -334,6 +363,7 @@ map MAP30
 	Music = "D_OPENIN"
 	SkyTexture = "SKY3"
 	InterText = clear
+	Author = "deathz0r"
 }
 
 map MAP31
@@ -347,6 +377,7 @@ map MAP31
 	SkyTexture = "SKY3"
 	ParTime = 0
 	InterTextSecret = clear
+	Author = "Xindage"
 }
 
 map MAP32
@@ -358,4 +389,5 @@ map MAP32
 	Music = "D_ULTIMA"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "Mechadon"
 }

--- a/lumps/p1_uminf.lmp
+++ b/lumps/p1_uminf.lmp
@@ -13,6 +13,7 @@ map E1M1
 	ParTime = 30
 	Episode = clear
 	Episode = "M_EPI1", "Outpost Outbreak", "1"
+	Author = "YukiHerz"
 }
 
 map E1M2
@@ -24,6 +25,7 @@ map E1M2
 	Music = "D_E1M2"
 	SkyTexture = "SKY1"
 	ParTime = 120
+	Author = "acc"
 }
 
 map E1M3
@@ -36,6 +38,7 @@ map E1M3
 	Music = "D_E1M3"
 	SkyTexture = "SKY1"
 	ParTime = 150
+	Author = "Paar"
 }
 
 map E1M4
@@ -47,6 +50,7 @@ map E1M4
 	Music = "D_E1M4"
 	SkyTexture = "SKY1"
 	ParTime = 180
+	Author = "GeekMarine"
 }
 
 map E1M5
@@ -58,6 +62,7 @@ map E1M5
 	Music = "D_E1M5"
 	SkyTexture = "SKY1"
 	ParTime = 90
+	Author = "Wereknight"
 }
 
 map E1M6
@@ -69,6 +74,7 @@ map E1M6
 	Music = "D_E1M6"
 	SkyTexture = "SKY1"
 	ParTime = 390
+	Author = "GeekMarine"
 }
 
 map E1M7
@@ -80,6 +86,7 @@ map E1M7
 	Music = "D_E1M7"
 	SkyTexture = "SKY1"
 	ParTime = 690
+	Author = "Kid Airbag"
 }
 
 map E1M8
@@ -110,6 +117,7 @@ map E1M8
 		" ",
 		"Just gotta hope that ship will launch",
 		"from these routed\, infested ruins..."
+	Author = "Xindage"
 }
 
 map E1M9
@@ -121,6 +129,7 @@ map E1M9
 	Music = "D_E1M9"
 	SkyTexture = "SKY1"
 	ParTime = 240
+	Author = "Mortrixs19"
 }
 
 map E2M1
@@ -133,6 +142,7 @@ map E2M1
 	SkyTexture = "SKY2"
 	ParTime = 120
 	Episode = "M_EPI2", "Ruin Upon Ruin", "2"
+	Author = "Xindage"
 }
 
 map E2M2
@@ -144,6 +154,7 @@ map E2M2
 	Music = "D_E2M2"
 	SkyTexture = "SKY2"
 	ParTime = 150
+	Author = "Hayden49"
 }
 
 map E2M3
@@ -155,6 +166,7 @@ map E2M3
 	Music = "D_E2M3"
 	SkyTexture = "SKY2"
 	ParTime = 180
+	Author = "SUNPYG Senpai"
 }
 
 map E2M4
@@ -166,6 +178,7 @@ map E2M4
 	Music = "D_E2M4"
 	SkyTexture = "SKY2"
 	ParTime = 270
+	Author = "Xindage"
 }
 
 map E2M5
@@ -178,6 +191,7 @@ map E2M5
 	Music = "D_E2M5"
 	SkyTexture = "SKY2"
 	ParTime = 300
+	Author = "Xindage"
 }
 
 map E2M6
@@ -189,6 +203,7 @@ map E2M6
 	Music = "D_E2M6"
 	SkyTexture = "SKY2"
 	ParTime = 150
+	Author = "Catoptromancy"
 }
 
 map E2M7
@@ -200,6 +215,7 @@ map E2M7
 	Music = "D_E2M7"
 	SkyTexture = "SKY2"
 	ParTime = 120
+	Author = "Xindage"
 }
 
 map E2M8
@@ -229,6 +245,7 @@ map E2M8
 		" ",
 		"You board the platform and fade away.",
 		"Next stop: Horizon."
+	Author = "Xindage"
 }
 
 map E2M9
@@ -240,6 +257,7 @@ map E2M9
 	Music = "D_E2M9"
 	SkyTexture = "SKY2"
 	ParTime = 360
+	Author = "Z0k"
 }
 
 map E3M1
@@ -252,6 +270,7 @@ map E3M1
 	SkyTexture = "SKY3"
 	ParTime = 30
 	Episode = "M_EPI3", "Event Horizon", "3"
+	Author = "Jayextee"
 }
 
 map E3M2
@@ -263,6 +282,7 @@ map E3M2
 	Music = "D_E3M2"
 	SkyTexture = "SKY3"
 	ParTime = 120
+	Author = "pan-te"
 }
 
 map E3M3
@@ -274,6 +294,7 @@ map E3M3
 	Music = "D_E3M3"
 	SkyTexture = "SKY3"
 	ParTime = 240
+	Author = "SgtCrispy"
 }
 
 map E3M4
@@ -285,6 +306,7 @@ map E3M4
 	Music = "D_E3M4"
 	SkyTexture = "SKY3"
 	ParTime = 270
+	Author = "GuyNamedErick"
 }
 
 map E3M5
@@ -296,6 +318,7 @@ map E3M5
 	Music = "D_E3M5"
 	SkyTexture = "SKY3"
 	ParTime = 0
+	Author = "SUNPYG Senpai"
 }
 
 map E3M6
@@ -308,6 +331,7 @@ map E3M6
 	Music = "D_E3M6"
 	SkyTexture = "SKY3"
 	ParTime = 180
+	Author = "Archfile"
 }
 
 map E3M7
@@ -319,6 +343,7 @@ map E3M7
 	Music = "D_E3M7"
 	SkyTexture = "SKY3"
 	ParTime = 300
+	Author = "Cacodemon Leader"
 }
 
 map E3M8
@@ -349,6 +374,7 @@ map E3M8
 		"Wherever or whatever that is, you pray",
 		"to any listening deity that there's",
 		"a working ship on the other side."
+	Author = "Torn"
 }
 
 map E3M9
@@ -360,6 +386,7 @@ map E3M9
 	Music = "D_E3M9"
 	SkyTexture = "SKY3"
 	ParTime = 570
+	Author = Angry Saint""
 }
 
 map E4M1

--- a/lumps/p2_uminf.lmp
+++ b/lumps/p2_uminf.lmp
@@ -13,6 +13,7 @@ map MAP01
 	ParTime = 30
 	Episode = clear
 	Episode = "M_EPI1", "Phase 2", "1"
+	Author = "Blastfrog, Xindage & Jon Dowland"
 }
 
 map MAP02
@@ -24,6 +25,7 @@ map MAP02
 	Music = "D_STALKS"
 	SkyTexture = "SKY1"
 	ParTime = 90
+	Author = "Siggi"
 }
 
 map MAP03
@@ -35,6 +37,7 @@ map MAP03
 	Music = "D_COUNTD"
 	SkyTexture = "SKY1"
 	ParTime = 120
+	Author = "SgtCrispy"
 }
 
 map MAP04
@@ -46,6 +49,7 @@ map MAP04
 	Music = "D_BETWEE"
 	SkyTexture = "SKY1"
 	ParTime = 120
+	Author = "Macro11_1"
 }
 
 map MAP05
@@ -57,6 +61,7 @@ map MAP05
 	Music = "D_DOOM"
 	SkyTexture = "SKY1"
 	ParTime = 150
+	Author = "Amarande"
 }
 
 map MAP06
@@ -87,6 +92,7 @@ map MAP06
 		"Planted your feet.",
 		"Checked your weapons.",
 		"Time to punch through."
+	Author = "Jayextee"
 }
 
 map MAP07
@@ -98,6 +104,7 @@ map MAP07
 	Music = "D_SHAWN"
 	SkyTexture = "SKY1"
 	ParTime = 150
+	Author = "Mortrixs19"
 }
 
 map MAP08
@@ -109,6 +116,7 @@ map MAP08
 	Music = "D_DDTBLU"
 	SkyTexture = "SKY1"
 	ParTime = 330
+	Author = "Boris Iwanski"
 }
 
 map MAP09
@@ -120,6 +128,7 @@ map MAP09
 	Music = "D_IN_CIT"
 	SkyTexture = "SKY1"
 	ParTime = 150
+	Author = "sajbear"
 }
 
 map MAP10
@@ -131,6 +140,7 @@ map MAP10
 	Music = "D_DEAD"
 	SkyTexture = "SKY1"
 	ParTime = 120
+	Author = "Xerent"
 }
 
 map MAP11
@@ -160,6 +170,7 @@ map MAP11
 		"Cities mean people.",
 		" ",
 		"Right?"
+	Author = "Kaiser"
 }
 
 map MAP12
@@ -171,6 +182,7 @@ map MAP12
 	Music = "D_THEDA2"
 	SkyTexture = "SKY2"
 	ParTime = 630
+	Author = "Z0k"
 }
 
 map MAP13
@@ -182,6 +194,7 @@ map MAP13
 	Music = "D_DOOM2"
 	SkyTexture = "SKY2"
 	ParTime = 180
+	Author = "Jayextee"
 }
 
 map MAP14
@@ -193,6 +206,7 @@ map MAP14
 	Music = "D_DDTBL2"
 	SkyTexture = "SKY2"
 	ParTime = 150
+	Author = "Jayextee"
 }
 
 map MAP15
@@ -224,6 +238,7 @@ map MAP15
 		"entire time\, locked inside of your brain?",
 		" ",
 		"You\'d rather not find out."
+	Author = "Z0k"
 }
 
 map MAP16
@@ -235,6 +250,7 @@ map MAP16
 	Music = "D_DEAD2"
 	SkyTexture = "SKY2"
 	ParTime = 120
+	Author = "Hyena"
 }
 
 map MAP17
@@ -246,6 +262,7 @@ map MAP17
 	Music = "D_STLKS3"
 	SkyTexture = "SKY2"
 	ParTime = 120
+	Author = "Jayextee"
 }
 
 map MAP18
@@ -257,6 +274,7 @@ map MAP18
 	Music = "D_ROMERO"
 	SkyTexture = "SKY2"
 	ParTime = 180
+	Author = "Jimmy"
 }
 
 map MAP19
@@ -268,6 +286,7 @@ map MAP19
 	Music = "D_SHAWN2"
 	SkyTexture = "SKY2"
 	ParTime = 210
+	Author = "Jayextee"
 }
 
 map MAP20
@@ -298,6 +317,7 @@ map MAP20
 		" ",
 		"This could be the beginning",
 		"of your freedom - or your doom."
+	Author = "Lazer"
 }
 
 map MAP21
@@ -309,6 +329,7 @@ map MAP21
 	Music = "D_COUNT2"
 	SkyTexture = "SKY3"
 	ParTime = 330
+	Author = "Mortrixs19"
 }
 
 map MAP22
@@ -320,6 +341,7 @@ map MAP22
 	Music = "D_DDTBL3"
 	SkyTexture = "SKY3"
 	ParTime = 420
+	Author = "Boris Iwanski"
 }
 
 map MAP23
@@ -331,6 +353,7 @@ map MAP23
 	Music = "D_AMPIE"
 	SkyTexture = "SKY3"
 	ParTime = 240
+	Author = "Submerge"
 }
 
 map MAP24
@@ -342,6 +365,7 @@ map MAP24
 	Music = "D_THEDA3"
 	SkyTexture = "SKY3"
 	ParTime = 420
+	Author = "Jayextee"
 }
 
 map MAP25
@@ -353,6 +377,7 @@ map MAP25
 	Music = "D_ADRIAN"
 	SkyTexture = "SKY3"
 	ParTime = 600
+	Author = "Cyb"
 }
 
 map MAP26
@@ -364,6 +389,7 @@ map MAP26
 	Music = "D_MESSG2"
 	SkyTexture = "SKY3"
 	ParTime = 270
+	Author = "GooseJelly"
 }
 
 map MAP27
@@ -375,6 +401,7 @@ map MAP27
 	Music = "D_ROMER2"
 	SkyTexture = "SKY3"
 	ParTime = 690
+	Author = "DOGB01"
 }
 
 map MAP28
@@ -386,6 +413,7 @@ map MAP28
 	Music = "D_TENSE"
 	SkyTexture = "SKY3"
 	ParTime = 450
+	Author = "Z0k"
 }
 
 map MAP29
@@ -397,6 +425,7 @@ map MAP29
 	Music = "D_SHAWN3"
 	SkyTexture = "SKY3"
 	ParTime = 300
+	Author = "Amarande"
 }
 
 map MAP30
@@ -426,6 +455,7 @@ map MAP30
 		"No one will know what happened here.",
 		" ",
 		"No one will ever find you again."
+	Author = "Cacodemon Leader"
 }
 
 map MAP31
@@ -456,6 +486,7 @@ map MAP31
 		"You will find your way back to the city,",
 		"but it will have to be on the other side",
 		"of a few homicidal mutants..."
+	Author = "Jayextee"
 }
 
 map MAP32
@@ -467,4 +498,5 @@ map MAP32
 	Music = "D_ULTIMA"
 	SkyTexture = "SKY3"
 	ParTime = 210
+	Author = "Catoptromancy"
 }


### PR DESCRIPTION
Not only is this field part of the `UMAPINFO` specification standard, ports such as Woof and KEX are capable of displaying the `author` of the map for the payer either as a "level announcement" or a log function in the console.

![woof0020](https://github.com/user-attachments/assets/9e7e8cff-537a-4f88-96d2-e891813f834b)