### PR TITLE
Fix typo in Phase 1 `UMAPINFO`

### DIFF
--- a/lumps/p1_uminf.lmp
+++ b/lumps/p1_uminf.lmp
@@ -386,7 +386,7 @@ map E3M9
 	Music = "D_E3M9"
 	SkyTexture = "SKY3"
 	ParTime = 570
-	Author = Angry Saint""
+	Author = "Angry Saint"
 }
 
 map E4M1


### PR DESCRIPTION
Breaks parsers. Now fixed.