### PR TITLE
Simplify the help screen

### DIFF
--- a/graphics/text/Makefile
+++ b/graphics/text/Makefile
@@ -70,59 +70,23 @@ help.png: text_strings helpbg.png
 	./smtextgen help.png 320x200                 \
 	   -background "helpbg.png"                  \
 	   150,2   "file:helpttl.png"                \
-	   10,20   "Weapons"                         \
-	   20,33   "file:../../sprites/csawa0.png"   \
-	   90,25   "file:../../sprites/shota0.png"   \
-	   90,40   "file:../../sprites/sgn2a0.png"   \
-	   154,15  "file:../../sprites/mguna0.png"   \
-	   161,35  "file:../../sprites/launa0.png"   \
-	   235,18  "file:../../sprites/plasa0.png"   \
-	   235,33  "file:../../sprites/bfuga0.png"   \
-	   10,62   "Bullets"                         \
-	   80,57   "file:../../sprites/ammoa0.png"   \
-	   68,62   "file:../../sprites/clipa0.png"   \
-	   113,62  "Shells"                          \
-	   180,57  "file:../../sprites/sboxa0.png"   \
-	   163,62  "file:../../sprites/shela0.png"   \
-	   252,60  "Backpack"                        \
-	   272,69  "file:../../sprites/bpaka0.png"   \
-	   10,85   "Missiles"                        \
-	   90,75   "file:../../sprites/broka0.png"   \
-	   76,75   "file:../../sprites/rocka0.png"   \
-	   158,85  "Energy"                          \
-	   225,76  "file:../../sprites/celpa0.png"   \
-	   206,84  "file:../../sprites/cella0.png"   \
-	   10,110  "Health"                          \
-	   63,106  "file:../../sprites/bon1a0.png"   \
-	   100,101  "file:../../sprites/media0.png"   \
-	   79,113  "file:../../sprites/stima0.png"   \
-	   132,102 "file:../../sprites/pstra0.png"   \
-	   180,110 "Armor"                           \
-	   276,105 "file:../../sprites/arm2b0.png"   \
-	   240,102 "file:../../sprites/arm1b0.png"   \
-	   225,109 "file:../../sprites/bon2b0.png"   \
-	   145,134 "Map"                             \
-	   175,122 "file:../../sprites/pmapa0.png"   \
-	   10,134  "Big Boost"                       \
-	   84,127  "file:../../sprites/soula0.png"   \
-	   110,127 "file:../../sprites/megaa0.png"   \
-	   10,155  "Light"                           \
-	   48,152  "file:../../sprites/pvisa0.png"   \
-	   34,177  "Cloak"                           \
-	   80,161  "file:../../sprites/pinsa0.png"   \
-	   119,177 "Invuln."                         \
-	   174,166 "file:../../sprites/pinva0.png"   \
-	   265,137 "Keys"                            \
-	   254,149 "file:../../sprites/rkeya0.png"   \
-	   271,149 "file:../../sprites/ykeya0.png"   \
-	   288,149 "file:../../sprites/bkeya0.png"   \
-	   255,173 "file:../../sprites/rskua0.png"   \
-	   273,173 "file:../../sprites/yskua0.png"   \
-	   291,173 "file:../../sprites/bskua0.png"   \
-	   130,155 "Rescue suit"                     \
-	   215,137 "file:../../sprites/suita0.png"   \
-	   2,192 "https://freedoom.github.io/"       \
-	   214,192 "<Esc> to return"
+	   175,23  "file:../../sprites/launa0.png"   \
+	   185,43  "file:../../sprites/shota0.png"   \
+	   240,35  "file:../../sprites/broka0.png"   \
+	   248,30  "file:../../sprites/shela0.png"   \
+	   267,23  "file:../../sprites/ammoa0.png"   \
+	   20,64   "file:../../sprites/media0.png"   \
+	   55,74   "file:../../sprites/stima0.png"   \
+	   170,92  "file:../../sprites/pinva0.png"   \
+	   200,100 "file:../../sprites/pvisa0.png"   \
+	   232,95  "file:../../sprites/pstra0.png"   \
+	   20,123  "file:../../sprites/rkeya0.png"   \
+	   35,123  "file:../../sprites/ykeya0.png"   \
+	   28,133  "file:../../sprites/bkeya0.png"   \
+	   62,123  "file:../../sprites/rskua0.png"   \
+	   54,136  "file:../../sprites/yskua0.png"   \
+	   69,136  "file:../../sprites/bskua0.png"   \
+	   10,30   "include:help.txt"
 	cp $@ ../
 
 

--- a/graphics/text/help.txt
+++ b/graphics/text/help.txt
@@ -1,0 +1,20 @@
+Build up your arsenal!
+Always look out for
+new weapons and ammo.
+
+                    You die if your health reaches
+                    zero. Health packs replenish
+                    your strength.
+
+Some rare items will
+give special powers
+and abilities.
+
+                    Some doors are locked! To open
+                    them you will have to find
+                    the right colored key.
+
+
+For more info, see the Freedoom manual:
+
+ https://freedoom.github.io/manual.pdf

--- a/graphics/text/help.txt
+++ b/graphics/text/help.txt
@@ -11,7 +11,7 @@ give special powers
 and abilities.
 
                     Some doors are locked! To open
-                    them you will have to find
+                    them, you will have to find
                     the right colored key.
 
 

--- a/graphics/text/help.txt
+++ b/graphics/text/help.txt
@@ -17,4 +17,4 @@ and abilities.
 
 For more info, see the Freedoom manual:
 
- https://freedoom.github.io/manual.pdf
+ https://freedoom.github.io/manual.txt


### PR DESCRIPTION
This fixes #1489, where the keys were being obscured by the menu skull that is drawn on the help screen by vanilla Doom. Rather than just shuffle around the contents of the help screen, I opted to simplify it by removing a lot of the clutter.

The old help screen was created before the Freedoom manual was added, so there's no need for us to include every in-game item. Instead, we can delegate to the manual by including a link to it, and cut things back to just a small selection of example items.