### PR TITLE
CI: Use the version of deutex from GHA Ubuntu

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -19,18 +19,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install python3-pil asciidoc unzip zip ruby dos2unix \
-                         inkscape
+                         inkscape deutex
         sudo gem install asciidoctor-pdf --pre
-    - name: Install Deutex
-      run: |
-        git clone https://github.com/Doom-Utils/deutex.git
-        cd deutex
-        git checkout v5.2.1
-        sudo apt install libpng-dev
-        ./bootstrap
-        ./configure
-        make
-        sudo make install
     - name: Build
       id: buildstep
       run: |


### PR DESCRIPTION
There's no need for us to recompile deutex every time we build Freedoom, since it's already in Github Actions. In a comment on #671 it was mentioned that this was done to work around a crash in the version of deutex in bionic, but that bug is long-fixed now.