### PR TITLE
build: add "-iwad" to deutex parameters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ADOCOPTS=--backend=html5 --conf-file=.adoc-layout.conf
 ASCIIDOC_MAN=a2x -f manpage
 CPP=scripts/simplecpp
 DEUTEX=deutex
-DEUTEX_BASIC_ARGS=-v0 -rate accept
+DEUTEX_BASIC_ARGS=-iwad -v0 -rate accept
 DEUTEX_ARGS=$(DEUTEX_BASIC_ARGS) -doom2 bootstrap/
 NODE_BUILDER=ZenNode
 NODE_BUILDER_LEVELS=e?m? dm?? map??


### PR DESCRIPTION
Basically no modern port uses the header but it does let you run it on DOS Doom without it throwing a warning.